### PR TITLE
[Fix] Restrict .values unwrapping to pandas/xarray containers (swev-id: pydata__xarray-2905)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ xarray/tests/data/*.grib.*.idx
 Icon*
 
 .ipynb_checkpoints
+.venv/

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -218,7 +218,10 @@ def as_compatible_data(data, fastpath=False):
         data = np.timedelta64(getattr(data, "value", data), "ns")
 
     # we don't want nested self-described arrays
-    data = getattr(data, "values", data)
+    if isinstance(data, xr.DataArray):
+        data = data.values
+    elif isinstance(data, (pd.Series, pd.DataFrame)):
+        data = data.values
 
     if isinstance(data, np.ma.MaskedArray):
         mask = np.ma.getmaskarray(data)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -49,6 +49,14 @@ pytestmark = [
 ]
 
 
+class HasValues:
+    values = np.array(["class-level"])
+
+    def __init__(self, token="instance"):
+        self.token = token
+        self.values = np.array([token])
+
+
 class TestDataArray:
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -7077,6 +7085,60 @@ def test_subclass_slots():
             pass
 
     assert str(e.value) == "MyArray must explicitly define __slots__"
+
+
+def test_loc_assignment_custom_object_with_values_kept():
+    array = xr.DataArray(
+        np.full(3, None, dtype=object),
+        dims="x",
+        coords={"x": [0, 1, 2]},
+    )
+    value = HasValues("payload")
+
+    array.loc[{"x": 1}] = value
+
+    assert array.dtype == object
+    assert array.values[1] is value
+    assert isinstance(array.values[1], HasValues)
+    assert not isinstance(array.values[1], np.ndarray)
+
+
+def test_assignment_pandas_series_unwrapped():
+    coords = ["a", "b", "c"]
+    array = xr.DataArray(np.zeros(3), dims="x", coords={"x": coords})
+    series = pd.Series([1, 2, 3], index=coords)
+
+    array.loc[dict(x=slice(None))] = series
+
+    assert_array_equal(array.values, series.values)
+
+    dataframe = pd.DataFrame(
+        [[10, 20], [30, 40]], index=[0, 1], columns=["y0", "y1"]
+    )
+    matrix = xr.DataArray(
+        np.zeros((2, 2)),
+        dims=["x", "y"],
+        coords={"x": [0, 1], "y": ["y0", "y1"]},
+    )
+
+    matrix.loc[{"x": slice(None), "y": slice(None)}] = dataframe
+
+    assert_array_equal(matrix.values, dataframe.values)
+
+
+def test_constructor_with_custom_object_values_property():
+    instance = HasValues("scalar")
+    scalar_array = xr.DataArray(instance)
+
+    assert scalar_array.dtype == object
+    assert scalar_array.item() is instance
+    assert isinstance(scalar_array.item(), HasValues)
+    assert not isinstance(scalar_array.item(), np.ndarray)
+
+    class_array = xr.DataArray(HasValues)
+
+    assert class_array.dtype == object
+    assert class_array.item() is HasValues
 
 
 def test_weakref():


### PR DESCRIPTION
## Summary
- update `as_compatible_data` to unwrap `.values` only for `xr.DataArray`, `pd.Series`, and `pd.DataFrame`
- add regression tests covering custom objects with `.values`, pandas Series assignment, and constructors
- ignore local `.venv/` helpers to keep virtual environments out of version control

## Reproduction Steps
```bash
LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib \
  .venv/bin/pytest -q \
  xarray/tests/test_dataarray.py::test_loc_assignment_custom_object_with_values_kept \
  xarray/tests/test_dataarray.py::test_assignment_pandas_series_unwrapped \
  xarray/tests/test_dataarray.py::test_constructor_with_custom_object_values_property
```

## Observed Failure (pre-fix)
```text
E   TypeError: Cannot convert numpy.ndarray to numpy.ndarray
pandas/_libs/lib.pyx:2555: TypeError

E   AssertionError: assert dtype('<U6') == object
```

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_dataarray.py::test_loc_assignment_custom_object_with_values_kept xarray/tests/test_dataarray.py::test_assignment_pandas_series_unwrapped xarray/tests/test_dataarray.py::test_constructor_with_custom_object_values_property`
- `.venv/bin/flake8 xarray/tests/test_dataarray.py xarray/core/variable.py`

## Task Reference
- #298
- #7