### PR TITLE
fix: preserve unicode index dtype (swev-id: pydata__xarray-3095)

### DIFF
--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1947,7 +1947,9 @@ class IndexVariable(Variable):
                 # point, which doesn't have a copy method, so make a deep copy
                 # of the underlying `pandas.MultiIndex` and create a new
                 # `PandasIndexAdapter` instance with it.
-                data = PandasIndexAdapter(self._data.array.copy(deep=True))
+                data = PandasIndexAdapter(
+                    self._data.array.copy(deep=True), dtype=self._data.dtype
+                )
             else:
                 data = self._data
         else:

--- a/xarray/tests/test_copy_unicode_index.py
+++ b/xarray/tests/test_copy_unicode_index.py
@@ -1,0 +1,80 @@
+import copy
+
+import numpy as np
+import pandas as pd
+
+import xarray as xr
+from xarray import IndexVariable, Variable
+
+
+def test_indexvariable_unicode_deep_copy_preserves_dtype():
+    values = np.array(["foo", "bar"], dtype="<U3")
+    index_var = IndexVariable("x", values)
+
+    shallow = index_var.copy(deep=False)
+    assert shallow.dtype == index_var.dtype
+    assert shallow.dtype.kind == "U"
+
+    deep = index_var.copy(deep=True)
+    assert deep.dtype == index_var.dtype
+    assert deep.dtype.kind == "U"
+
+    deepcopy_var = copy.deepcopy(index_var)
+    assert deepcopy_var.dtype == index_var.dtype
+    assert deepcopy_var.dtype.kind == "U"
+
+
+def test_dataarray_unicode_coord_copy_methods_preserve_dtype():
+    coord_values = np.array(["alpha", "beta"], dtype="<U5")
+    data = np.arange(coord_values.size)
+    array = xr.DataArray(data, dims="x", coords={"x": coord_values})
+
+    for copier in (
+        lambda a: a.copy(deep=True),
+        lambda a: a.copy(deep=False),
+        copy.copy,
+        copy.deepcopy,
+    ):
+        result = copier(array)
+        assert result.coords["x"].dtype == array.coords["x"].dtype
+        assert result.coords["x"].dtype.kind == "U"
+
+
+def test_dataset_unicode_coord_copy_methods_preserve_dtype():
+    coord_values = np.array(["gamma", "delta"], dtype="<U5")
+    ds = xr.Dataset(
+        coords={"x": coord_values},
+        data_vars={"z": ("x", np.array(["eps", "zeta"], dtype="<U4"))},
+    )
+
+    for copier in (
+        lambda d: d.copy(deep=True),
+        lambda d: d.copy(deep=False),
+        copy.copy,
+        copy.deepcopy,
+    ):
+        result = copier(ds)
+        assert result.coords["x"].dtype == ds.coords["x"].dtype
+        assert result.coords["x"].dtype.kind == "U"
+
+
+def test_unicode_index_edge_cases():
+    empty_index = IndexVariable("x", np.array([], dtype="<U1"))
+    assert empty_index.copy(deep=True).dtype.kind == "U"
+    assert copy.deepcopy(empty_index).dtype.kind == "U"
+
+    multi_index = IndexVariable(
+        "x", pd.MultiIndex.from_product([["a", "b"], [1, 2]])
+    )
+    assert multi_index.copy(deep=True).dtype == object
+    assert copy.deepcopy(multi_index).dtype == object
+
+    pandas_string = IndexVariable(
+        "x", pd.Index(["one", "two"], dtype="string")
+    )
+    assert pandas_string.copy(deep=True).dtype == object
+    assert copy.deepcopy(pandas_string).dtype == object
+
+    scalar_unicode = Variable((), np.array("omega", dtype="<U5"))
+    assert scalar_unicode.copy(deep=True).dtype.kind == "U"
+    assert copy.deepcopy(scalar_unicode).dtype.kind == "U"


### PR DESCRIPTION
## Summary
- preserve unicode index dtype by propagating the original dtype when deep-copying IndexVariable data
- add regression coverage for IndexVariable, DataArray, and Dataset unicode coordinate copy scenarios plus edge cases

## Reproduction
1. Checkout `pydata__xarray-3095` and install the local venv deps (`numpy==1.26.4`, `pandas==1.5.3`, etc.).
2. Run:
   ```bash
   LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib \
   .venv/bin/python - <<'PY'
   import numpy as np
   import xarray as xr

   arr = xr.DataArray([1], dims=['x'], coords={'x': np.array(['foo'], dtype='<U3')})
   assert arr.coords['x'].dtype.kind == 'U'
   arr2 = arr.copy(deep=True)
   print(arr2.coords['x'].dtype)
   assert arr2.coords['x'].dtype.kind == 'U'
   PY
   ```
3. On the base branch the final assertion raises `AssertionError` and prints `object`, showing the dtype regression.

## Root Cause
`IndexVariable.copy(deep=True)` rebuilds a ``PandasIndexAdapter`` without passing through the existing dtype. Pandas backs the adapter with a new ``Index`` whose inferred dtype is ``object``, so unicode coordinates lose their `<U*>` dtype during deep copies.

## Change Details
- inject `dtype=self._data.dtype` when constructing a new ``PandasIndexAdapter`` while deep-copying index data
- add targeted tests covering deep/shallow copies on ``IndexVariable``, ``DataArray``, and ``Dataset`` unicode coords plus empty, MultiIndex, pandas string, and scalar unicode edge cases

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_copy_unicode_index.py`
- `.venv/bin/flake8 xarray/core/variable.py xarray/tests/test_copy_unicode_index.py`
