### PR TITLE
fix: swev-id: pydata__xarray-3151 ignore identical non-monotonic coords

### DIFF
--- a/xarray/core/combine.py
+++ b/xarray/core/combine.py
@@ -500,8 +500,9 @@ def combine_by_coords(datasets, compat='no_conflicts', data_vars='all',
                                    data_vars=data_vars, coords=coords,
                                    fill_value=fill_value)
 
-        # Check the overall coordinates are monotonically increasing
-        for dim in concatenated.dims:
+        # Check the overall coordinates are monotonically increasing along
+        # dimensions where datasets were actually concatenated.
+        for dim in concat_dims:
             if dim in concatenated:
                 indexes = concatenated.indexes.get(dim)
                 if not (indexes.is_monotonic_increasing

--- a/xarray/tests/test_combine.py
+++ b/xarray/tests/test_combine.py
@@ -3,6 +3,7 @@ from itertools import product
 from datetime import datetime
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from xarray import (DataArray, Dataset, concat, combine_by_coords,
@@ -617,6 +618,91 @@ class TestCombineAuto:
         with raises_regex(ValueError, "does not have monotonic global indexes"
                                       " along dimension x"):
             combine_by_coords([ds1, ds0])
+
+    def test_combine_by_coords_identical_nonmonotonic_bystander(self):
+        y = ['a', 'c', 'b']
+        left = Dataset(
+            data_vars={'data': (('x', 'y'), np.arange(9).reshape(3, 3))},
+            coords={'x': [1, 2, 3], 'y': y}
+        )
+        right = Dataset(
+            data_vars={'data': (('x', 'y'), np.arange(12).reshape(4, 3) + 9)},
+            coords={'x': [4, 5, 6, 7], 'y': y}
+        )
+
+        expected = concat([left, right], dim='x')
+        actual = combine_by_coords([left, right])
+        assert_identical(actual, expected)
+
+    def test_combine_by_coords_nonidentical_nonmonotonic_raises(self):
+        y = ['a', 'c', 'b']
+        left = Dataset(
+            data_vars={'data': (('x', 'y'), np.arange(9).reshape(3, 3))},
+            coords={'x': [0, 1, 5], 'y': y}
+        )
+        right = Dataset(
+            data_vars={'data': (('x', 'y'), np.arange(6).reshape(2, 3) + 9)},
+            coords={'x': [2, 3], 'y': y}
+        )
+
+        with raises_regex(
+            ValueError, "monotonic global indexes along dimension x"
+        ):
+            combine_by_coords([right, left])
+
+    def test_combine_by_coords_multiindex_bystander_nonmonotonic(self):
+        y = pd.MultiIndex.from_tuples(
+            [('a', 0), ('c', 0), ('b', 0)],
+            names=['outer', 'inner']
+        )
+        left = Dataset(
+            data_vars={
+                'data': (('x', 'y'), np.arange(6).reshape(2, 3)),
+            },
+            coords={
+                'x': [0, 1],
+                'y': y,
+            }
+        )
+        right = Dataset(
+            data_vars={
+                'data': (('x', 'y'), np.arange(6, 12).reshape(2, 3)),
+            },
+            coords={
+                'x': [2, 3],
+                'y': y,
+            }
+        )
+
+        expected = concat([left, right], dim='x')
+        actual = combine_by_coords([left, right])
+        assert_identical(actual, expected)
+
+    def test_combine_by_coords_scalar_and_nondim_coords_unaffected(self):
+        labels = ['z', 'y']
+        left = Dataset(
+            data_vars={'data': (('x', 'sample'), np.arange(4).reshape(2, 2))},
+            coords={
+                'x': [0, 1],
+                'sample': ['u', 'v'],
+                'label': ('sample', labels),
+                'run': 0,
+            }
+        )
+        right = Dataset(
+            data_vars={'data': (('x', 'sample'),
+                                np.arange(4, 8).reshape(2, 2))},
+            coords={
+                'x': [2, 3],
+                'sample': ['u', 'v'],
+                'label': ('sample', labels),
+                'run': 0,
+            }
+        )
+
+        expected = concat([left, right], dim='x')
+        actual = combine_by_coords([left, right])
+        assert_identical(actual, expected)
 
 
 @pytest.mark.filterwarnings("ignore:In xarray version 0.13 `auto_combine` "


### PR DESCRIPTION
## Summary
- restrict the post-concat monotonicity check to inferred concat dims
- add regression coverage for identical non-monotonic dims (including MultiIndex and non-dimension coords)

## Reproduction (pre-fix)
1. python3 -m venv .venv
2. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pip install numpy==1.26.4 pandas==1.5.3 pytest==8.2.2 flake8==3.9.2
3. LD_LIBRARY_PATH=<above> PYTHONPATH=/workspace/xarray .venv/bin/python - <<'PY'
import numpy as np
import xarray as xr

yCoord = ['a', 'c', 'b']

ds1 = xr.Dataset(
    data_vars={'data': (('x', 'y'), np.random.rand(3, 3))},
    coords={'x': [1, 2, 3], 'y': yCoord},
)

ds2 = xr.Dataset(
    data_vars={'data': (('x', 'y'), np.random.rand(4, 3))},
    coords={'x': [4, 5, 6, 7], 'y': yCoord},
)

xr.combine_by_coords((ds1, ds2))
PY

### Observed failure
```
/workspace/xarray/xarray/plot/plot.py:243: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if args is ():
Traceback (most recent call last):
  File "<stdin>", line 26, in <module>
  File "/workspace/xarray/xarray/core/combine.py", line 509, in combine_by_coords
    raise ValueError("Resulting object does not have monotonic"
ValueError: Resulting object does not have monotonic global indexes along dimension y
```

## Testing
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/pytest -q xarray/tests/test_combine.py::TestCombineAuto
- PYTHONPATH=/workspace/xarray .venv/bin/flake8 xarray/core/combine.py xarray/tests/test_combine.py

Fixes #10

_Avoid triggering CI manually per instructions._