### PR TITLE
Fix Dataset.merge(DataArray) coercion (swev-id: pydata__xarray-3677)

### DIFF
--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -805,6 +805,11 @@ def dataset_merge_method(
 ) -> _MergeResult:
     """Guts of the Dataset.merge method.
     """
+    from .dataarray import DataArray
+
+    if isinstance(other, DataArray):
+        other = other.to_dataset()
+
     # we are locked into supporting overwrite_vars for the Dataset.merge
     # method due for backwards compatibility
     # TODO: consider deprecating it?

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -253,3 +253,40 @@ class TestMergeMethod:
         with pytest.raises(xr.MergeError):
             ds3 = xr.Dataset({"a": ("y", [2, 3]), "y": [1, 2]})
             ds1.merge(ds3, compat="no_conflicts")
+
+    def test_merge_dataarray_matches_function(self):
+        ds = xr.Dataset({"a": 0})
+        da = xr.DataArray(1, name="b")
+
+        expected = xr.merge([ds, da])
+        actual = ds.merge(da)
+
+        assert actual.identical(expected)
+
+    def test_merge_dataarray_requires_name(self):
+        ds = xr.Dataset({"a": 0})
+        da = xr.DataArray(1)
+
+        with raises_regex(ValueError, "without providing an explicit name"):
+            ds.merge(da)
+
+    def test_merge_dataarray_overwrite_conflict(self):
+        ds = xr.Dataset({"a": 0})
+        da = xr.DataArray(1, name="a")
+
+        with pytest.raises(xr.MergeError):
+            ds.merge(da)
+
+        merged = ds.merge(da, overwrite_vars="a")
+        expected = xr.Dataset({"a": 1})
+
+        assert merged.identical(expected)
+
+    def test_merge_dataarray_join_parity(self):
+        ds = xr.Dataset({"a": ("x", [1, 2])}, coords={"x": [0, 1]})
+        da = xr.DataArray([3, 4], dims="x", coords={"x": [1, 2]}, name="b")
+
+        expected = xr.merge([ds, da], join="outer")
+        actual = ds.merge(da, join="outer")
+
+        assert actual.identical(expected)


### PR DESCRIPTION
Fixes #12.

## Reproduction
```python
import xarray as xr

ds = xr.Dataset({'a': 0})
da = xr.DataArray(1, name='b')

expected = xr.merge([ds, da])  # works fine
print(expected)

ds.merge(da)  # fails
```

## Observed error
```
<xarray.Dataset>
Dimensions:  ()
Data variables:
    a        int64 0
    b        int64 1

Traceback (most recent call last):
  File "mwe.py", line 6, in <module>
    actual = ds.merge(da)
  File "/home/tegn500/Documents/Work/Code/xarray/xarray/core/dataset.py", line 3591, in merge
    fill_value=fill_value,
  File "/home/tegn500/Documents/Work/Code/xarray/xarray/core/merge.py", line 835, in dataset_merge_method
    objs, compat, join, priority_arg=priority_arg, fill_value=fill_value
  File "/home/tegn500/Documents/Work/Code/xarray/xarray/core/merge.py", line 548, in merge_core
    coerced = coerce_pandas_values(objects)
  File "/home/tegn500/Documents/Work/Code/xarray/xarray/core/merge.py", line 394, in coerce_pandas_values
    for k, v in obj.items():
  File "/home/tegn500/Documents/Work/Code/xarray/xarray/core/common.py", line 233, in __getattr__
    "{!r} object has no attribute {!r}".format(type(self).__name__, name)
AttributeError: 'DataArray' object has no attribute 'items'
```

## Summary
- coerce `DataArray` inputs to `Dataset` inside `dataset_merge_method`
- add regression tests covering named, unnamed, overwrite, and join parity behaviors
- keep merge method parity with `xr.merge` for `DataArray` inputs

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_merge.py`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 xarray/core/merge.py xarray/tests/test_merge.py`