### PR TITLE
fix: swev-id: pydata__xarray-3305 quantile honors keep_attrs

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2784,7 +2784,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                             raise IndexError(
                                 "Axis {a} is out of bounds of the expanded"
                                 " dimension size {dim}.".format(
-                                    a=a, v=k, dim=result_ndim
+                                    a=a, dim=result_ndim
                                 )
                             )
 
@@ -4768,7 +4768,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
                             # the former is often more efficient
                             reduce_dims = None
                         variables[name] = var.quantile(
-                            q, dim=reduce_dims, interpolation=interpolation
+                            q,
+                            dim=reduce_dims,
+                            interpolation=interpolation,
+                            keep_attrs=keep_attrs,
                         )
 
             else:

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -3,7 +3,7 @@ import itertools
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from distutils.version import LooseVersion
-from typing import Any, Hashable, Mapping, Union
+from typing import Any, Hashable, Mapping, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -1592,7 +1592,13 @@ class Variable(
         """
         return self.broadcast_equals(other, equiv=duck_array_ops.array_notnull_equiv)
 
-    def quantile(self, q, dim=None, interpolation="linear"):
+    def quantile(
+        self,
+        q,
+        dim=None,
+        interpolation="linear",
+        keep_attrs: Optional[bool] = None,
+    ):
         """Compute the qth quantile of the data along the specified dimension.
 
         Returns the qth quantiles(s) of the array elements.
@@ -1615,6 +1621,10 @@ class Variable(
                 * higher: ``j``.
                 * nearest: ``i`` or ``j``, whichever is nearest.
                 * midpoint: ``(i + j) / 2``.
+        keep_attrs : bool, optional
+            If True, the variable's attributes (``attrs``) are copied to the
+            result. If False, attributes are dropped. If None (default), the
+            global ``keep_attrs`` option is used (defaults to False).
 
         Returns
         -------
@@ -1658,7 +1668,10 @@ class Variable(
         qs = np.nanpercentile(
             self.data, q * 100.0, axis=axis, interpolation=interpolation
         )
-        return Variable(new_dims, qs)
+        if keep_attrs is None:
+            keep_attrs = _get_keep_attrs(default=False)
+        attrs = self._attrs if keep_attrs else None
+        return Variable(new_dims, qs, attrs=attrs)
 
     def rank(self, dim, pct=False):
         """Ranks the data.

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2310,6 +2310,28 @@ class TestDataArray:
                 )
                 np.testing.assert_allclose(actual.values, expected)
 
+    def test_quantile_keep_attrs_true(self):
+        array = DataArray([0.0, 1.0, 2.0], dims="x", attrs={"units": "m"})
+
+        result = array.quantile(0.5, keep_attrs=True)
+
+        assert result.attrs == array.attrs
+
+    def test_quantile_keep_attrs_false(self):
+        array = DataArray([0.0, 1.0, 2.0], dims="x", attrs={"units": "m"})
+
+        result = array.quantile(0.5, keep_attrs=False)
+
+        assert result.attrs == {}
+
+    def test_quantile_keep_attrs_from_options(self):
+        array = DataArray([0.0, 1.0, 2.0], dims="x", attrs={"units": "m"})
+
+        with xr.set_options(keep_attrs=True):
+            result = array.quantile(0.5)
+
+        assert result.attrs == array.attrs
+
     def test_reduce_keep_attrs(self):
         # Test dropped attrs
         vm = self.va.mean()

--- a/xarray/tests/test_variable.py
+++ b/xarray/tests/test_variable.py
@@ -1488,6 +1488,28 @@ class TestVariable(VariableSubclassobjects):
                 expected = np.nanpercentile(self.d, np.array(q) * 100, axis=axis)
                 np.testing.assert_allclose(actual.values, expected)
 
+    def test_quantile_keep_attrs_true(self):
+        v = Variable(["x"], [0.0, 1.0, 2.0], attrs={"units": "m"})
+
+        result = v.quantile(0.5, keep_attrs=True)
+
+        assert result.attrs == v.attrs
+
+    def test_quantile_keep_attrs_false(self):
+        v = Variable(["x"], [0.0, 1.0, 2.0], attrs={"units": "m"})
+
+        result = v.quantile(0.5, keep_attrs=False)
+
+        assert result.attrs == {}
+
+    def test_quantile_keep_attrs_from_options(self):
+        v = Variable(["x"], [0.0, 1.0, 2.0], attrs={"units": "m"})
+
+        with set_options(keep_attrs=True):
+            result = v.quantile(0.5)
+
+        assert result.attrs == v.attrs
+
     @requires_dask
     def test_quantile_dask_raises(self):
         # regression for GH1524


### PR DESCRIPTION
## Summary
- preserve `Variable.quantile` attributes when `keep_attrs` resolves True
- forward `keep_attrs` through `Dataset.quantile`
- add regression tests for DataArray/Variable quantile attribute retention

## Issue
- Fixes #11

## Reproduction Steps (MCVE)
1. Construct a `DataArray` with attributes, e.g. `xr.DataArray([0.0, 1.0, 2.0], attrs={"units": "m"})`.
2. Call `quantile(0.5, keep_attrs=True)` or enable `xr.set_options(keep_attrs=True)` and call `quantile(0.5)`.
3. Observe that `result.attrs` is empty instead of preserving `{"units": "m"}`.

Reproduced with:
```
LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib \
  .venv/bin/pytest -q xarray/tests/test_dataarray.py::TestDataArray::test_quantile_keep_attrs_true \
  xarray/tests/test_dataarray.py::TestDataArray::test_quantile_keep_attrs_from_options
```

### Observed Failure
```
_________________ TestDataArray.test_quantile_keep_attrs_true __________________
E       AssertionError: assert OrderedDict() == OrderedDict([('units', 'm')])
E         Right contains 1 more item:
E         {'units': 'm'}

_____________ TestDataArray.test_quantile_keep_attrs_from_options ______________
E       AssertionError: assert OrderedDict() == OrderedDict([('units', 'm')])
E         Right contains 1 more item:
E         {'units': 'm'}

2 failed, 19 warnings in 0.80s
```

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_dataarray.py::TestDataArray::test_quantile_keep_attrs_true xarray/tests/test_dataarray.py::TestDataArray::test_quantile_keep_attrs_false xarray/tests/test_dataarray.py::TestDataArray::test_quantile_keep_attrs_from_options`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_variable.py::TestVariable::test_quantile xarray/tests/test_variable.py::TestVariable::test_quantile_keep_attrs_true xarray/tests/test_variable.py::TestVariable::test_quantile_keep_attrs_false xarray/tests/test_variable.py::TestVariable::test_quantile_keep_attrs_from_options`
- `.venv/bin/flake8 xarray/tests/test_dataarray.py xarray/tests/test_variable.py xarray/core/variable.py xarray/core/dataset.py`

## Post-fix Result
- Quantile computations now keep attributes when requested while respecting the global `keep_attrs` option.