### PR TITLE
feat: swev-id: pydata__xarray-3993 add coord kwarg to DataArray.integrate

### DIFF
--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -410,7 +410,7 @@ trapezoidal rule using their coordinates,
 
 .. ipython:: python
 
-    a.integrate("x")
+    a.integrate(coord="x")
 
 .. note::
     These methods are limited to simple cartesian geometry. Differentiation

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -43,6 +43,14 @@ Breaking changes
   By `Aureliana Barghini <https://github.com/aurghs>`_.
 
 
+Deprecations
+~~~~~~~~~~~~
+- :py:meth:`DataArray.integrate` now mirrors :py:meth:`Dataset.integrate` by
+  accepting the ``coord`` argument for specifying the spacing coordinate.
+  Supplying the ``dim`` argument is deprecated and will be removed in a future
+  release.
+
+
 New Features
 ~~~~~~~~~~~~
 - Significantly higher ``unstack`` performance on numpy-backed arrays which

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3481,21 +3481,28 @@ class DataArray(AbstractArray, DataWithCoords):
         return self._from_temp_dataset(ds)
 
     def integrate(
-        self, dim: Union[Hashable, Sequence[Hashable]], datetime_unit: str = None
+        self,
+        coord: Optional[Union[Hashable, Sequence[Hashable]]] = None,
+        datetime_unit: Optional[str] = None,
+        dim: Optional[Union[Hashable, Sequence[Hashable]]] = None,
     ) -> "DataArray":
         """ integrate the array with the trapezoidal rule.
 
         .. note::
-            This feature is limited to simple cartesian geometry, i.e. dim
+            This feature is limited to simple cartesian geometry, i.e. ``coord``
             must be one dimensional.
 
         Parameters
         ----------
-        dim : hashable, or sequence of hashable
-            Coordinate(s) used for the integration.
+        coord : hashable, or sequence of hashable, optional
+            Coordinate(s) used for the integration. When provided positionally,
+            this argument selects the coordinate for spacing without any
+            deprecation warning.
         datetime_unit : {"Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", \
                          "ps", "fs", "as"}, optional
             Can be used to specify the unit if datetime coordinate is used.
+        dim : hashable, or sequence of hashable, optional
+            Deprecated name for ``coord``.
 
         Returns
         -------
@@ -3523,12 +3530,38 @@ class DataArray(AbstractArray, DataWithCoords):
           * x        (x) float64 0.0 0.1 1.1 1.2
         Dimensions without coordinates: y
         >>>
-        >>> da.integrate("x")
+        >>> da.integrate(coord="x")
         <xarray.DataArray (y: 3)>
         array([5.4, 6.6, 7.8])
         Dimensions without coordinates: y
         """
-        ds = self._to_temp_dataset().integrate(dim, datetime_unit)
+        if coord is None and dim is None:
+            raise TypeError("DataArray.integrate() missing required argument 'coord'")
+
+        if coord is not None and dim is not None:
+            def _as_tuple(value: Union[Hashable, Sequence[Hashable]]) -> Tuple[Hashable, ...]:
+                if isinstance(value, Sequence) and not isinstance(value, str):
+                    return tuple(value)
+                return (value,)
+
+            if _as_tuple(coord) != _as_tuple(dim):
+                raise ValueError(
+                    "Only one of 'coord' or deprecated 'dim' may be supplied; use 'coord'."
+                )
+
+        if coord is None:
+            coord = dim
+
+        if dim is not None:
+            warnings.warn(
+                "DataArray.integrate: argument 'dim' is deprecated; use 'coord' to "
+                "specify the coordinate for spacing. 'dim' will be removed in a future "
+                "xarray release.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
+        ds = self._to_temp_dataset().integrate(coord, datetime_unit=datetime_unit)
         return self._from_temp_dataset(ds)
 
     def unify_chunks(self) -> "DataArray":

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6572,7 +6572,7 @@ def test_integrate(dask):
     ds = xr.Dataset({"var": da})
 
     # along x
-    actual = da.integrate("x")
+    actual = da.integrate(coord="x")
     # coordinate that contains x should be dropped.
     expected_x = xr.DataArray(
         np.trapz(da.compute(), da["x"], axis=0),
@@ -6580,7 +6580,7 @@ def test_integrate(dask):
         coords={k: v for k, v in da.coords.items() if "x" not in v.dims},
     )
     assert_allclose(expected_x, actual.compute())
-    assert_equal(ds["var"].integrate("x"), ds.integrate("x")["var"])
+    assert_equal(ds["var"].integrate(coord="x"), ds.integrate(coord="x")["var"])
 
     # make sure result is also a dask array (if the source is dask array)
     assert isinstance(actual.data, type(da.data))
@@ -6597,11 +6597,65 @@ def test_integrate(dask):
     assert_equal(ds["var"].integrate("y"), ds.integrate("y")["var"])
 
     # along x and y
-    actual = da.integrate(("y", "x"))
+    actual = da.integrate(coord=("y", "x"))
     assert actual.ndim == 0
 
     with pytest.raises(ValueError):
         da.integrate("x2d")
+
+
+def test_dataarray_integrate_dim_deprecated():
+    da = xr.DataArray(
+        np.arange(4),
+        dims=["x"],
+        coords={"x": np.array([0.0, 0.1, 0.4, 0.9])},
+    )
+
+    with pytest.warns(FutureWarning, match="argument 'dim' is deprecated"):
+        actual = da.integrate(dim="x")
+
+    expected = xr.DataArray(np.trapz(da.data, da["x"].data))
+    assert_allclose(expected, actual)
+
+
+def test_dataarray_integrate_coord_and_dim_same():
+    da = xr.DataArray(
+        np.linspace(0, 1, 5),
+        dims=["x"],
+        coords={"x": np.linspace(0.5, 2.5, 5)},
+    )
+
+    with pytest.warns(FutureWarning, match="argument 'dim' is deprecated"):
+        actual = da.integrate(coord="x", dim="x")
+
+    expected = xr.DataArray(np.trapz(da.data, da["x"].data))
+    assert_allclose(expected, actual)
+
+
+def test_dataarray_integrate_coord_dim_mismatch():
+    da = xr.DataArray(
+        np.arange(6).reshape(3, 2),
+        dims=["x", "y"],
+        coords={"x": [0.0, 0.5, 0.75], "y": [1.0, 2.0]},
+    )
+
+    with pytest.raises(
+        ValueError, match="Only one of 'coord' or deprecated 'dim' may be supplied"
+    ):
+        da.integrate(coord="x", dim="y")
+
+
+def test_dataarray_integrate_non_monotonic_coord():
+    da = xr.DataArray(
+        np.array([1.0, 2.0, 0.0, 4.0]),
+        dims=["x"],
+        coords={"x": np.array([0.0, 0.5, 0.2, 1.0])},
+    )
+
+    actual = da.integrate(coord="x")
+    expected = np.trapz(da.data, da["x"].data)
+
+    np.testing.assert_allclose(actual.item(), expected)
 
 
 @pytest.mark.parametrize("dask", [True, False])
@@ -6636,7 +6690,7 @@ def test_trapz_datetime(dask, which_datetime):
     if dask and has_dask:
         da = da.chunk({"time": 4})
 
-    actual = da.integrate("time", datetime_unit="D")
+    actual = da.integrate(coord="time", datetime_unit="D")
     expected_data = np.trapz(
         da.data,
         duck_array_ops.datetime_to_numeric(da["time"].data, datetime_unit="D"),
@@ -6652,7 +6706,7 @@ def test_trapz_datetime(dask, which_datetime):
     # make sure result is also a dask array (if the source is dask array)
     assert isinstance(actual.data, type(da.data))
 
-    actual2 = da.integrate("time", datetime_unit="h")
+    actual2 = da.integrate(coord="time", datetime_unit="h")
     assert_allclose(actual, actual2 / 24.0)
 
 


### PR DESCRIPTION
## Summary
- addresses #17 / Task ID 303 by aligning `DataArray.integrate` with the `Dataset` API
- accept `coord` on `DataArray.integrate` while deprecating `dim`, with warnings and conflict checks
- update tests, docs, and release notes to cover the new keyword and deprecation messaging

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/pytest -q xarray/tests/test_dataset.py::test_integrate xarray/tests/test_dataset.py::test_dataarray_integrate_dim_deprecated xarray/tests/test_dataset.py::test_dataarray_integrate_coord_and_dim_same xarray/tests/test_dataset.py::test_dataarray_integrate_coord_dim_mismatch xarray/tests/test_dataset.py::test_dataarray_integrate_non_monotonic_coord xarray/tests/test_dataset.py::test_trapz_datetime` (8 passed, 2 skipped)
- `.venv/bin/flake8 xarray/core/dataarray.py xarray/tests/test_dataset.py`

## Reproduction
Before patch:
```python
import numpy as np, xarray as xr

da = xr.DataArray(np.arange(4), dims=["x"], coords={"x": [0.0, 0.1, 1.1, 1.2]})
da.integrate(coord="x")
```
Stack trace:
```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
TypeError: DataArray.integrate() got an unexpected keyword argument 'coord'
```

After patch:
```python
import numpy as np, xarray as xr

da = xr.DataArray(np.arange(4), dims=["x"], coords={"x": [0.0, 0.1, 1.1, 1.2]})
result = da.integrate(coord="x")
np.testing.assert_allclose(result.item(), np.trapz(da.data, da["x"].data))
```