### PR TITLE
Fix: to_unstacked_dataset broken for single-dim variables (swev-id: pydata__xarray-4094)

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1961,7 +1961,7 @@ class DataArray(AbstractArray, DataWithCoords):
         # pull variables out of datarray
         data_dict = {}
         for k in variables:
-            data_dict[k] = self.sel({variable_dim: k}).squeeze(drop=True)
+            data_dict[k] = self.sel({variable_dim: k}, drop=True).squeeze(drop=True)
 
         # unstacked dataset
         return Dataset(data_dict)

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3045,6 +3045,23 @@ class TestDataset:
         d0 = D.isel(x=0)
         assert_identical(d0, x0)
 
+    def test_to_stacked_array_to_unstacked_dataset_single_dim_roundtrip(self):
+        arr = xr.DataArray(
+            np.arange(3),
+            coords=[("x", [0, 1, 2])],
+            attrs={"units": "m"},
+        )
+        ds = xr.Dataset({"a": arr, "b": arr})
+
+        stacked = ds.to_stacked_array("y", sample_dims=["x"])
+        roundtripped = stacked.to_unstacked_dataset("y")
+
+        xr.testing.assert_identical(ds, roundtripped)
+        assert set(roundtripped.coords) == set(ds.coords)
+        xr.testing.assert_identical(roundtripped.coords["x"], ds.coords["x"])
+        assert roundtripped["a"].attrs == ds["a"].attrs
+        assert roundtripped["b"].attrs == ds["b"].attrs
+
     def test_to_stacked_array_to_unstacked_dataset_different_dimension(self):
         # test when variables have different dimensionality
         a, b = create_test_stacked_array()


### PR DESCRIPTION
## Summary
- drop the stacked variable coordinate during selection in `DataArray.to_unstacked_dataset` so single-dimension variables round-trip cleanly
- add a regression covering stack→unstack when every variable shares a single sample dimension and ensure coordinates/attrs survive

Fixes #21.

## MCVE
```python
import numpy as np
import xarray as xr
arr = xr.DataArray(
     np.arange(3),
     coords=[[0, 1, 2]],
 )
data = xr.Dataset({"a": arr, "b": arr})
stacked = data.to_stacked_array('y', sample_dims=['x'])
unstacked = stacked.to_unstacked_dataset('y')
print(unstacked)
```

## Observed failure
```
/workspace/xarray/xarray/core/concat.py:389: FutureWarning: unique with argument that is not not a Series, Index, ExtensionArray, or np.ndarray is deprecated and will raise in a future version.
  common_dims = tuple(pd.unique([d for v in vars for d in v.dims]))
Traceback (most recent call last):
  File "<stdin>", line 9, in <module>
  File "/workspace/xarray/xarray/core/dataarray.py", line 1967, in to_unstacked_dataset
    return Dataset(data_dict)
           ^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/dataset.py", line 543, in __init__
    variables, coord_names, dims, indexes, _ = merge_data_and_coords(
                                               ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/merge.py", line 466, in merge_data_and_coords
    return merge_core(
           ^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/merge.py", line 597, in merge_core
    variables, out_indexes = merge_collected(collected, prioritized, compat=compat)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/merge.py", line 228, in merge_collected
    merged_vars[name] = unique_variable(name, variables, compat)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/merge.py", line 142, in unique_variable
    raise MergeError(
xarray.core.merge.MergeError: conflicting values for variable 'y' on objects to be combined. You can skip this check by specifying compat='override'.
```

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_dataset.py::TestDataset::test_to_stacked_array_to_unstacked_dataset xarray/tests/test_dataset.py::TestDataset::test_to_stacked_array_to_unstacked_dataset_single_dim_roundtrip xarray/tests/test_dataset.py::TestDataset::test_to_stacked_array_to_unstacked_dataset_different_dimension`

## Environment
- Python 3.11.14 (Nix profile)
- numpy 1.26.4 (downgraded from 2.4.0 to restore `np.unicode_` compatibility)
- pandas 2.3.3
- xarray commit a64cf2d5476e7bbda099b34c40b7be1880dbd39a (branch pydata__xarray-4094)