### PR TITLE
Fix boolean weighted mean normalization by casting weights to numeric (swev-id: pydata__xarray-4075)

### DIFF
--- a/xarray/core/weighted.py
+++ b/xarray/core/weighted.py
@@ -142,7 +142,12 @@ class Weighted:
         # we need to mask data values that are nan; else the weights are wrong
         mask = da.notnull()
 
-        sum_of_weights = self._reduce(mask, self.weights, dim=dim, skipna=False)
+        if self.weights.dtype.kind == "b":
+            weights = self.weights.astype("float64")
+        else:
+            weights = self.weights
+
+        sum_of_weights = self._reduce(mask, weights, dim=dim, skipna=False)
 
         # 0-weights are not valid
         valid_weights = sum_of_weights != 0.0

--- a/xarray/tests/test_weighted.py
+++ b/xarray/tests/test_weighted.py
@@ -309,3 +309,52 @@ def test_weighted_operations_keep_attr_da_in_ds(operation):
     result = getattr(data.weighted(weights), operation)(keep_attrs=True)
 
     assert data.a.attrs == result.a.attrs
+
+
+def test_weighted_mean_boolean_mcve():
+    da = xr.DataArray([1.0, 1.0, 1.0])
+    weights = xr.DataArray([True, True, False])
+    result = da.weighted(weights).mean()
+    assert result.item() == 1.0
+
+
+def test_weighted_sum_of_weights_boolean_no_nan():
+    da = xr.DataArray([1.0, 2.0, 3.0])
+    weights = xr.DataArray([True, True, False])
+    result = da.weighted(weights).sum_of_weights()
+    assert_equal(result, xr.DataArray(2.0))
+
+
+def test_weighted_sum_and_mean_boolean_no_nan():
+    da = xr.DataArray([1.0, 3.0, 2.0])
+    weights = xr.DataArray([True, True, False])
+    weighted = da.weighted(weights)
+    assert_allclose(weighted.sum(), xr.DataArray(4.0))
+    assert_allclose(weighted.mean(), xr.DataArray(2.0))
+
+
+@pytest.mark.parametrize("skipna", [True, False])
+def test_weighted_boolean_nan_behavior(skipna):
+    da = xr.DataArray([1.0, np.nan, 3.0])
+    weights = xr.DataArray([True, True, True])
+    result = da.weighted(weights).mean(skipna=skipna)
+
+    if skipna:
+        assert_allclose(result, xr.DataArray(2.0))
+    else:
+        assert result.isnull().item()
+
+
+def test_weighted_boolean_all_false_weights():
+    da = xr.DataArray([1.0, 2.0, 3.0])
+    weights = xr.DataArray([False, False, False])
+    weighted = da.weighted(weights)
+
+    sum_of_weights = weighted.sum_of_weights()
+    assert sum_of_weights.isnull().item()
+
+    weighted_sum = weighted.sum()
+    assert_allclose(weighted_sum, xr.DataArray(0.0))
+
+    mean = weighted.mean()
+    assert mean.isnull().item()


### PR DESCRIPTION
## Summary
- cast boolean weights to float64 in `Weighted._sum_of_weights` before reduction
- add regression coverage for boolean-weighted sum, mean, NaN behavior, and all-false weights based on the MCVE

## Testing
- source .venv/bin/activate && export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && PYTHONPATH=. pytest -q xarray/tests/test_weighted.py::test_weighted_mean_boolean_mcve
- source .venv/bin/activate && export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && PYTHONPATH=. pytest -q xarray/tests/test_weighted.py::test_weighted_sum_of_weights_boolean_no_nan
- source .venv/bin/activate && export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && PYTHONPATH=. pytest -q xarray/tests/test_weighted.py::test_weighted_sum_and_mean_boolean_no_nan
- source .venv/bin/activate && export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && PYTHONPATH=. pytest -q xarray/tests/test_weighted.py::test_weighted_boolean_nan_behavior
- source .venv/bin/activate && export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && PYTHONPATH=. pytest -q xarray/tests/test_weighted.py::test_weighted_boolean_all_false_weights
- source .venv/bin/activate && export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && PYTHONPATH=. pytest -q xarray/tests/test_weighted.py

Fixes #19.