### PR TITLE
fix: swev-id: pydata__xarray-4356 support multi-axis min_count

### DIFF
--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -47,7 +47,14 @@ def _maybe_null_out(result, axis, mask, min_count=1):
         nan_count = mask.sum()
 
     valid_count = total - nan_count
-    keep_mask = valid_count >= min_count
+    null_mask = valid_count < min_count
+    keep_mask = np.logical_not(null_mask)
+
+    is_dask = isinstance(result, dask_array_type)
+    if not is_dask:
+        has_nulls = bool(np.any(null_mask)) if hasattr(null_mask, "any") else bool(null_mask)
+        if not has_nulls:
+            return result
 
     result_dtype = getattr(result, "dtype", None)
     if result_dtype is None:
@@ -55,7 +62,7 @@ def _maybe_null_out(result, axis, mask, min_count=1):
 
     dtype, fill_value = dtypes.maybe_promote(result_dtype)
 
-    if getattr(result, "ndim", 0) > 0 or isinstance(result, dask_array_type):
+    if is_dask or getattr(result, "ndim", 0) > 0:
         result = result.astype(dtype, copy=False)
         return where_method(result, keep_mask, fill_value)
 

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -1,4 +1,7 @@
+import math
+
 import numpy as np
+from numpy.core.multiarray import normalize_axis_index
 
 from . import dtypes, nputils, utils
 from .duck_array_ops import _dask_or_eager_func, count, fillna, isnull, where_method
@@ -23,27 +26,43 @@ def _replace_nan(a, val):
 
 
 def _maybe_null_out(result, axis, mask, min_count=1):
-    """
-    xarray version of pandas.core.nanops._maybe_null_out
-    """
-    if hasattr(axis, "__len__"):  # if tuple or list
-        raise ValueError(
-            "min_count is not available for reduction with more than one dimensions."
-        )
+    """xarray version of pandas.core.nanops._maybe_null_out."""
 
-    if axis is not None and getattr(result, "ndim", False):
-        null_mask = (mask.shape[axis] - mask.sum(axis) - min_count) < 0
-        if null_mask.any():
-            dtype, fill_value = dtypes.maybe_promote(result.dtype)
-            result = result.astype(dtype)
-            result[null_mask] = fill_value
+    mask_ndim = getattr(mask, "ndim", 0)
 
-    elif getattr(result, "dtype", None) not in dtypes.NAT_TYPES:
-        null_mask = mask.size - mask.sum()
-        if null_mask < min_count:
-            result = np.nan
+    if axis is None:
+        axes = tuple(range(mask_ndim))
+    else:
+        if np.isscalar(axis):
+            axes = (int(axis),)
+        else:
+            axes = tuple(int(a) for a in np.atleast_1d(axis).tolist())
+        axes = tuple(normalize_axis_index(ax, mask_ndim) for ax in axes)
 
-    return result
+    if axes:
+        total = math.prod(mask.shape[ax] for ax in axes)
+        nan_count = mask.sum(axis=axes)
+    else:
+        total = mask.size
+        nan_count = mask.sum()
+
+    valid_count = total - nan_count
+    keep_mask = valid_count >= min_count
+
+    result_dtype = getattr(result, "dtype", None)
+    if result_dtype is None:
+        result_dtype = np.asarray(result).dtype
+
+    dtype, fill_value = dtypes.maybe_promote(result_dtype)
+
+    if getattr(result, "ndim", 0) > 0 or isinstance(result, dask_array_type):
+        result = result.astype(dtype, copy=False)
+        return where_method(result, keep_mask, fill_value)
+
+    if keep_mask:
+        return result
+
+    return fill_value
 
 
 def _nan_argminmax_object(func, fill_value, value, axis=None, **kwargs):

--- a/xarray/core/nanops.py
+++ b/xarray/core/nanops.py
@@ -48,28 +48,70 @@ def _maybe_null_out(result, axis, mask, min_count=1):
 
     valid_count = total - nan_count
     null_mask = valid_count < min_count
-    keep_mask = np.logical_not(null_mask)
 
-    is_dask = isinstance(result, dask_array_type)
-    if not is_dask:
-        has_nulls = bool(np.any(null_mask)) if hasattr(null_mask, "any") else bool(null_mask)
-        if not has_nulls:
-            return result
+    if isinstance(null_mask, (bool, np.bool_)):
+        keep_mask = not null_mask
+    else:
+        keep_mask = np.logical_not(null_mask)
 
     result_dtype = getattr(result, "dtype", None)
     if result_dtype is None:
         result_dtype = np.asarray(result).dtype
 
-    dtype, fill_value = dtypes.maybe_promote(result_dtype)
+    is_dask = isinstance(result, dask_array_type)
+    result_ndim = getattr(result, "ndim", 0)
 
-    if is_dask or getattr(result, "ndim", 0) > 0:
-        result = result.astype(dtype, copy=False)
+    na_capable = (
+        np.issubdtype(result_dtype, np.floating)
+        or np.issubdtype(result_dtype, np.complexfloating)
+        or np.issubdtype(result_dtype, np.datetime64)
+        or np.issubdtype(result_dtype, np.timedelta64)
+        or result_dtype.kind == "O"
+    )
+
+    if na_capable:
+        if not is_dask:
+            has_nulls = (
+                null_mask
+                if isinstance(null_mask, (bool, np.bool_))
+                else bool(np.any(null_mask))
+            )
+            if not has_nulls:
+                return result
+
+        fill_value = dtypes.get_fill_value(result_dtype)
+
+        if not is_dask and result_ndim == 0:
+            keep_scalar = (
+                keep_mask
+                if isinstance(keep_mask, (bool, np.bool_))
+                else bool(keep_mask)
+            )
+            return result if keep_scalar else fill_value
+
         return where_method(result, keep_mask, fill_value)
 
-    if keep_mask:
-        return result
+    if not is_dask:
+        has_nulls = (
+            null_mask
+            if isinstance(null_mask, (bool, np.bool_))
+            else bool(np.any(null_mask))
+        )
+        if not has_nulls:
+            return result
 
-    return fill_value
+    dtype, fill_value = dtypes.maybe_promote(result_dtype)
+
+    if not is_dask and result_ndim == 0:
+        keep_scalar = (
+            keep_mask
+            if isinstance(keep_mask, (bool, np.bool_))
+            else bool(keep_mask)
+        )
+        return result if keep_scalar else fill_value
+
+    result = result.astype(dtype, copy=False)
+    return where_method(result, keep_mask, fill_value)
 
 
 def _nan_argminmax_object(func, fill_value, value, axis=None, **kwargs):

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -616,6 +616,31 @@ def test_min_count_multi_axis_dtype_preserved():
     assert result.item() == values.sum()
 
 
+@requires_dask
+@pytest.mark.parametrize("dtype", [np.int64, np.bool_])
+def test_min_count_multi_axis_dask_promotes_non_na_capable(dtype):
+    values = np.arange(1, 7).reshape(2, 3).astype(dtype)
+    da = DataArray(values, dims=("dim_0", "dim_1")).chunk({"dim_0": 1, "dim_1": 3})
+
+    result = da.sum(dim=("dim_0", "dim_1"), skipna=True, min_count=1)
+
+    expected_dtype, _ = dtypes.maybe_promote(np.dtype(dtype))
+    assert result.dtype == expected_dtype
+    assert result.compute().item() == values.sum(dtype=np.int64)
+
+
+@requires_dask
+@pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+def test_min_count_multi_axis_dask_preserves_na_capable(dtype):
+    values = np.arange(1, 7, dtype=np.float64).reshape(2, 3).astype(dtype)
+    da = DataArray(values, dims=("dim_0", "dim_1")).chunk({"dim_0": 1, "dim_1": 3})
+
+    result = da.sum(dim=("dim_0", "dim_1"), skipna=True, min_count=1)
+
+    assert result.dtype == np.dtype(dtype)
+    assert_allclose(result.compute(), values.sum())
+
+
 @pytest.mark.parametrize(
     "func, expectations",
     [

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -606,6 +606,16 @@ def test_nansum_min_count_multi_axis_mcve():
     assert result.item() == pytest.approx(21.0)
 
 
+def test_min_count_multi_axis_dtype_preserved():
+    values = np.arange(1, 7, dtype=np.int64).reshape(2, 3)
+    da = DataArray(values, dims=("dim_0", "dim_1"))
+
+    result = da.sum(dim=("dim_0", "dim_1"), skipna=True, min_count=values.size)
+
+    assert result.dtype == values.dtype
+    assert result.item() == values.sum()
+
+
 @pytest.mark.parametrize(
     "func, expectations",
     [

--- a/xarray/tests/test_duck_array_ops.py
+++ b/xarray/tests/test_duck_array_ops.py
@@ -595,6 +595,82 @@ def test_min_count(dim_num, dtype, dask, func, aggdim):
     assert_dask_array(actual, dask)
 
 
+def test_nansum_min_count_multi_axis_mcve():
+    da = DataArray(
+        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        dims=("dim_0", "dim_1"),
+    )
+
+    result = da.sum(dim=("dim_0", "dim_1"), skipna=True, min_count=1)
+
+    assert result.item() == pytest.approx(21.0)
+
+
+@pytest.mark.parametrize(
+    "func, expectations",
+    [
+        (
+            "sum",
+            {
+                1: [14.0, 31.0],
+                4: [14.0, np.nan],
+                6: [np.nan, np.nan],
+            },
+        ),
+        (
+            "prod",
+            {
+                1: [72.0, 1056.0],
+                4: [72.0, np.nan],
+                6: [np.nan, np.nan],
+            },
+        ),
+    ],
+)
+def test_min_count_multi_axis_thresholds(func, expectations):
+    values = np.array(
+        [
+            [[1.0, np.nan, 3.0], [4.0, np.nan, 6.0]],
+            [[np.nan, 8.0, np.nan], [np.nan, 11.0, 12.0]],
+        ]
+    )
+    da = DataArray(values, dims=("dim_0", "dim_1", "dim_2"))
+
+    for min_count, expected in expectations.items():
+        actual = getattr(da, func)(
+            dim=("dim_1", "dim_2"), skipna=True, min_count=min_count
+        )
+        expected_da = DataArray(
+            np.array(expected, dtype=float),
+            dims=("dim_0",),
+        )
+        assert_allclose(actual, expected_da)
+
+
+@pytest.mark.parametrize("func", ["sum", "prod"])
+@pytest.mark.parametrize("dask", [False, True])
+def test_min_count_multi_axis_scalar_nan(func, dask):
+    if dask and not has_dask:
+        pytest.skip("requires dask")
+
+    values = np.arange(1, 13).reshape(2, 2, 3)
+    da = DataArray(values, dims=("dim_0", "dim_1", "dim_2"))
+    if dask:
+        da = da.chunk({"dim_0": 1, "dim_1": 2, "dim_2": 3})
+
+    min_count = values.size + 1
+    actual = getattr(da, func)(
+        dim=("dim_0", "dim_1", "dim_2"), skipna=True, min_count=min_count
+    )
+
+    assert actual.dtype == np.float64
+    if dask:
+        assert isinstance(actual.data, dask_array_type)
+        actual = actual.compute()
+
+    assert np.isnan(actual.values)
+
+
 @pytest.mark.parametrize("func", ["sum", "prod"])
 def test_min_count_dataset(func):
     da = construct_dataarray(2, dtype=float, contains_nan=True, dask=False)


### PR DESCRIPTION
## Summary
- update `_maybe_null_out` to normalize multi-axis reductions and branch dtype handling by backend/NA-capability (NumPy preserves original dtype when possible while dask promotes non-NA types lazily)
- add regression tests covering tuple-axis `min_count` for sum/prod, including NumPy/dask dtype expectations and scalar promotion checks
- ensure scalar reductions promote dtype when `min_count` thresholds are not met

Resolves #20  
Task ID: 306

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/pytest -q xarray/tests/test_duck_array_ops.py -k min_count`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/flake8 xarray/core/nanops.py xarray/tests/test_duck_array_ops.py`

## Reproduction (pre-fix)
1. `nix profile add nixpkgs#python311`
2. `cd /workspace/xarray`
3. `python3 -m venv .venv`
4. `.venv/bin/pip install numpy==1.26.4 pandas==1.5.3 pytest==8.2.2 flake8==3.9.2`
5. `export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib`
6. `PYTHONPATH=/workspace/xarray .venv/bin/python - <<'PY'
import numpy as np
import xarray as xr

da = xr.DataArray(np.arange(21).reshape(3, 7), dims=("dim_0", "dim_1"))
da.sum(dim=("dim_0", "dim_1"), skipna=True, min_count=1)
PY`

### Stack trace
```
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "/workspace/xarray/xarray/core/common.py", line 46, in wrapped_func
    return self.reduce(func, dim, axis, skipna=skipna, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/dataarray.py", line 2347, in reduce
    var = self.variable.reduce(func, dim, axis, keep_attrs, keepdims, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/variable.py", line 1640, in reduce
    data = func(input_data, axis=axis, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/duck_array_ops.py", line 335, in f
    return func(values, axis=axis, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/nanops.py", line 115, in nansum
    return _maybe_null_out(result, axis, mask, min_count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/nanops.py", line 30, in _maybe_null_out
    raise ValueError(
ValueError: min_count is not available for reduction with more than one dimensions.
```