### PR TITLE
fix: copy override attrs (swev-id: pydata__xarray-4629)

### DIFF
--- a/xarray/core/merge.py
+++ b/xarray/core/merge.py
@@ -501,7 +501,7 @@ def merge_attrs(variable_attrs, combine_attrs):
     if combine_attrs == "drop":
         return {}
     elif combine_attrs == "override":
-        return variable_attrs[0]
+        return dict(variable_attrs[0])
     elif combine_attrs == "no_conflicts":
         result = dict(variable_attrs[0])
         for attrs in variable_attrs[1:]:

--- a/xarray/tests/test_concat.py
+++ b/xarray/tests/test_concat.py
@@ -280,6 +280,16 @@ class TestConcatDataset:
             actual = concat([ds1, ds2], dim="x", combine_attrs=combine_attrs)
             assert_identical(actual, expected[combine_attrs])
 
+    def test_concat_override_attrs_copies_dataset_attrs(self):
+        ds1 = Dataset({"a": ("x", [0, 1])}, attrs={"meta": "left"})
+        ds2 = Dataset({"a": ("x", [2, 3])}, attrs={"meta": "right"})
+
+        merged = concat([ds1, ds2], dim="x", combine_attrs="override")
+        merged.attrs["meta"] = "merged"
+        merged.attrs["note"] = "mutated"
+
+        assert ds1.attrs == {"meta": "left"}
+
     def test_concat_promote_shape(self):
         # mixed dims within variables
         objs = [Dataset({}, {"x": 0}), Dataset({"x": [1]})]
@@ -524,6 +534,16 @@ class TestConcatDataArray:
         for combine_attrs in expected:
             actual = concat([da1, da2], dim="x", combine_attrs=combine_attrs)
             assert_identical(actual, expected[combine_attrs])
+
+    def test_concat_override_attrs_copies_dataarray_attrs(self):
+        da1 = DataArray([0, 1], dims="x", attrs={"meta": "left"})
+        da2 = DataArray([2, 3], dims="x", attrs={"meta": "right"})
+
+        merged = concat([da1, da2], dim="x", combine_attrs="override")
+        merged.attrs["meta"] = "merged"
+        merged.attrs["note"] = "mutated"
+
+        assert da1.attrs == {"meta": "left"}
 
 
 @pytest.mark.parametrize("attr1", ({"a": {"meta": [10, 20, 30]}}, {"a": [1, 2, 3]}, {}))

--- a/xarray/tests/test_merge.py
+++ b/xarray/tests/test_merge.py
@@ -109,6 +109,26 @@ class TestMergeFunction:
             expected.attrs = expected_attrs
             assert actual.identical(expected)
 
+    def test_merge_override_attrs_copies_dataset_attrs(self):
+        ds1 = xr.Dataset({"a": ("x", [1, 2])}, attrs={"source": "left"})
+        ds2 = xr.Dataset({"b": ("x", [3, 4])}, attrs={"source": "right"})
+
+        merged = xr.merge([ds1, ds2], combine_attrs="override")
+        merged.attrs["source"] = "merged"
+        merged.attrs["note"] = "mutated"
+
+        assert ds1.attrs == {"source": "left"}
+
+    def test_merge_override_attrs_copies_dataarray_attrs(self):
+        da1 = xr.DataArray([1, 2], dims="x", name="a", attrs={"source": "left"})
+        da2 = xr.DataArray([3, 4], dims="x", name="b", attrs={"source": "right"})
+
+        merged = xr.merge([da1, da2], combine_attrs="override")
+        merged.attrs["source"] = "merged"
+        merged.attrs["note"] = "mutated"
+
+        assert da1.attrs == {"source": "left"}
+
     def test_merge_dicts_simple(self):
         actual = xr.merge([{"foo": 0}, {"bar": "one"}, {"baz": 3.5}])
         expected = xr.Dataset({"foo": 0, "bar": "one", "baz": 3.5})


### PR DESCRIPTION
## Summary
- Fixes #22 by copying attrs when `combine_attrs='override'` to avoid mutating the source object
- Add regression tests for Dataset and DataArray merges plus concat to lock in the copy semantics

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_merge.py::TestMergeFunction::test_merge_override_attrs_copies_dataset_attrs xarray/tests/test_merge.py::TestMergeFunction::test_merge_override_attrs_copies_dataarray_attrs xarray/tests/test_concat.py::TestConcatDataset::test_concat_override_attrs_copies_dataset_attrs xarray/tests/test_concat.py::TestConcatDataArray::test_concat_override_attrs_copies_dataarray_attrs`
- `.venv/bin/flake8 xarray/core/merge.py xarray/tests/test_merge.py xarray/tests/test_concat.py`

## Reproduction
1. Checkout `pydata__xarray-4629`
2. Run `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_merge.py::TestMergeFunction::test_merge_override_attrs_copies_dataset_attrs`
3. Observe failure:
```
E       AssertionError: assert {'note': 'mutated', 'source': 'merged'} == {'source': 'left'}
E         Differing items:
E         {'source': 'merged'} != {'source': 'left'}
E         Left contains 1 more item:
E         {'note': 'mutated'}
```

## CI
- Not run (per instructions)