### PR TITLE
xr.where: honor keep_attrs and OPTIONS[keep_attrs]

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1727,7 +1727,7 @@ def dot(*arrays, dims=None, **kwargs):
     return result.transpose(*all_dims, missing_dims="ignore")
 
 
-def where(cond, x, y):
+def where(cond, x, y, *, keep_attrs: bool = None):
     """Return elements from `x` or `y` depending on `cond`.
 
     Performs xarray-like broadcasting across input arguments.
@@ -1743,6 +1743,14 @@ def where(cond, x, y):
         values to choose from where `cond` is True
     y : scalar, array, Variable, DataArray or Dataset
         values to choose from where `cond` is False
+
+    Parameters
+    ----------
+    keep_attrs : bool, optional
+        Whether to preserve attributes on the result. If None (default),
+        uses the global option OPTIONS["keep_attrs"]. When True, attributes
+        from the first xarray argument are copied to the output; when False,
+        attributes are dropped.
 
     Returns
     -------
@@ -1817,6 +1825,7 @@ def where(cond, x, y):
         join="exact",
         dataset_join="exact",
         dask="allowed",
+        keep_attrs=keep_attrs,
     )
 
 

--- a/xarray/tests/test_where_attrs.py
+++ b/xarray/tests/test_where_attrs.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+import xarray as xr
+from xarray import set_options
+
+
+def test_xr_where_keep_attrs_true_dataarray():
+    da = xr.DataArray(
+        np.arange(5), dims=["t"], attrs={"units": "m", "desc": "test"}
+    )
+    cond = da < 3
+    out = xr.where(cond, da, da * 10, keep_attrs=True)
+    assert out.attrs == da.attrs
+
+
+def test_xr_where_keep_attrs_false_dataarray():
+    da = xr.DataArray(np.arange(5), dims=["t"], attrs={"a": 1})
+    cond = da < 3
+    out = xr.where(cond, da, da * 10, keep_attrs=False)
+    assert out.attrs == {}
+
+
+def test_xr_where_respects_global_option_dataarray():
+    da = xr.DataArray(np.arange(5), dims=["t"], attrs={"a": 1})
+    cond = da < 3
+    with set_options(keep_attrs=True):
+        out = xr.where(cond, da, da * 10)
+        assert out.attrs == da.attrs
+    with set_options(keep_attrs=False):
+        out2 = xr.where(cond, da, da * 10)
+        assert out2.attrs == {}
+
+
+def test_xr_where_keep_attrs_dataset():
+    ds = xr.Dataset(
+        {"a": ("t", np.arange(5))}, attrs={"title": "ds"}
+    )
+    ds["a"].attrs = {"units": "m"}
+    cond = ds["a"] < 3
+
+    out_true = xr.where(cond, ds, ds * 10, keep_attrs=True)
+    assert out_true.attrs == ds.attrs
+    assert out_true["a"].attrs == ds["a"].attrs
+
+    out_false = xr.where(cond, ds, ds * 10, keep_attrs=False)
+    assert out_false.attrs == {}
+    assert out_false["a"].attrs == {}
+


### PR DESCRIPTION
Summary
- xr.where now exposes keep_attrs (default None) and forwards it to apply_ufunc.
- When keep_attrs=True, attrs from the first xarray argument are preserved; when False, attrs are dropped. If None, honors xarray OPTIONS['keep_attrs'].
- Added tests to verify DataArray and Dataset attrs propagation.

Rationale
- Align xr.where with DataArray.where behavior and apply_ufunc’s keep_attrs handling.

Notes
- Focused on attrs propagation only; dtype casting behavior remains unchanged (DataArray.where with other omitted promotes to float with NaN; xr.where dtype follows x/y dtype promotion).
