### PR TITLE
fix: swev-id: pydata__xarray-4695 handle DataArray.loc method dims

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -196,7 +196,7 @@ class _LocIndexer:
             # expand the indexer so we can handle Ellipsis
             labels = indexing.expanded_indexer(key, self.data_array.ndim)
             key = dict(zip(self.data_array.dims, labels))
-        return self.data_array.sel(**key)
+        return self.data_array.sel(key)
 
     def __setitem__(self, key, value) -> None:
         if not utils.is_dict_like(key):

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1090,6 +1090,30 @@ class TestDataArray:
         assert_identical(da[:3, :4], da.loc[["a", "b", "c"], np.arange(4)])
         assert_identical(da[:, :4], da.loc[:, self.ds["y"] < 4])
 
+    def test_loc_dimension_named_method(self):
+        data = DataArray(
+            np.arange(6).reshape(2, 3),
+            dims=["x", "method"],
+            coords={"x": [0, 1], "method": ["nearest", "pad", "backfill"]},
+        )
+
+        expected = data.sel({"method": "nearest"})
+        actual = data.loc[{"method": "nearest"}]
+
+        assert_identical(actual, expected)
+
+    def test_sel_method_keyword_retained(self):
+        data = DataArray(
+            [0, 1, 2],
+            dims=["x"],
+            coords={"x": [0.0, 1.0, 2.0]},
+        )
+
+        expected = data.sel(x=1.0)
+        actual = data.sel(x=1.2, method="nearest")
+
+        assert_identical(actual, expected)
+
     def test_loc_datetime64_value(self):
         # regression test for https://github.com/pydata/xarray/issues/4283
         t = np.array(["2017-09-05T12", "2017-09-05T15"], dtype="datetime64[ns]")


### PR DESCRIPTION
## Summary
- call `DataArray.sel` with a positional dict in `_LocIndexer.__getitem__` so dimensions named `method` no longer collide with the `method=` keyword
- add regression tests covering `.loc` with a `method` dimension and preserving `.sel(..., method="nearest")`

## Issue
- Closes #29

## MCVE
```python
import xarray as xr

da = xr.DataArray([0, 1], dims=["method"], coords={"method": ["a", "b"]})
print(da.loc[{"method": "a"}])
```
_Pre-fix output:_
```
<xarray.DataArray (method: 2)>
array([0, 1])
Coordinates:
  * method   (method) <U1 'a' 'b'
```
The selection returns the full array instead of the label "a".

## Local Setup
- `python3 -m venv .venv`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pip install numpy==1.26.4 pandas==1.5.3 pytest==8.2.2 flake8==3.9.2`

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 xarray/core/dataarray.py xarray/tests/test_dataarray.py`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_dataarray.py::TestDataArray::test_loc_dimension_named_method xarray/tests/test_dataarray.py::TestDataArray::test_sel_method_keyword_retained`