### PR TITLE
swev-id: pydata__xarray-4687 add keep_attrs support to xr.where

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1727,7 +1727,7 @@ def dot(*arrays, dims=None, **kwargs):
     return result.transpose(*all_dims, missing_dims="ignore")
 
 
-def where(cond, x, y):
+def where(cond, x, y, *, keep_attrs: bool = None):
     """Return elements from `x` or `y` depending on `cond`.
 
     Performs xarray-like broadcasting across input arguments.
@@ -1743,6 +1743,9 @@ def where(cond, x, y):
         values to choose from where `cond` is True
     y : scalar, array, Variable, DataArray or Dataset
         values to choose from where `cond` is False
+    keep_attrs : bool, optional
+        If ``True``, copy attributes from the first argument to the result.
+        If ``False``, drop attributes. Defaults to ``OPTIONS["keep_attrs"]``.
 
     Returns
     -------
@@ -1808,8 +1811,12 @@ def where(cond, x, y):
     Dataset.where, DataArray.where :
         equivalent methods
     """
+    resolved_keep_attrs = keep_attrs
+    if resolved_keep_attrs is None:
+        resolved_keep_attrs = _get_keep_attrs(default=False)
+
     # alignment for three arguments is complicated, so don't support it yet
-    return apply_ufunc(
+    result = apply_ufunc(
         duck_array_ops.where,
         cond,
         x,
@@ -1817,7 +1824,29 @@ def where(cond, x, y):
         join="exact",
         dataset_join="exact",
         dask="allowed",
+        keep_attrs=resolved_keep_attrs,
     )
+
+    if resolved_keep_attrs and hasattr(result, "data_vars"):
+        source_data_vars = None
+        for candidate in (x, y):
+            if hasattr(candidate, "data_vars"):
+                source_data_vars = candidate.data_vars
+                break
+            if is_dict_like(candidate):
+                source_data_vars = candidate
+                break
+
+        if source_data_vars is not None:
+            for name in result.data_vars:
+                try:
+                    source_var = source_data_vars[name]
+                except (KeyError, TypeError):
+                    source_var = None
+                if source_var is not None:
+                    result[name].attrs = dict(getattr(source_var, "attrs", {}))
+
+    return result
 
 
 def polyval(coord, coeffs, degree_dim="degree"):

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1841,7 +1841,7 @@ def where(cond, x, y, *, keep_attrs: bool = None):
             for name in result.data_vars:
                 try:
                     source_var = source_data_vars[name]
-                except (KeyError, TypeError):
+                except KeyError:
                     source_var = None
                 if source_var is not None:
                     result[name].attrs = dict(getattr(source_var, "attrs", {}))

--- a/xarray/tests/test_where_attrs.py
+++ b/xarray/tests/test_where_attrs.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+import xarray as xr
+
+
+def test_xr_where_keep_attrs_true_dataarray() -> None:
+    cond = np.array([True, False])
+    data = xr.DataArray([1, 2], dims=["x"], attrs={"source": "x"})
+    other = xr.DataArray([3, 4], dims=["x"], attrs={"source": "y"})
+
+    result = xr.where(cond, data, other, keep_attrs=True)
+
+    assert result.attrs == data.attrs
+
+
+def test_xr_where_keep_attrs_false_dataarray() -> None:
+    cond = np.array([True, False])
+    data = xr.DataArray([1, 2], dims=["x"], attrs={"source": "x"})
+    other = xr.DataArray([3, 4], dims=["x"], attrs={"source": "y"})
+
+    result = xr.where(cond, data, other, keep_attrs=False)
+
+    assert result.attrs == {}
+
+
+def test_xr_where_respects_global_option_dataarray() -> None:
+    cond = np.array([True, False])
+    data = xr.DataArray([1, 2], dims=["x"], attrs={"source": "x"})
+    other = xr.DataArray([3, 4], dims=["x"], attrs={"source": "y"})
+
+    with xr.set_options(keep_attrs=True):
+        result_keep = xr.where(cond, data, other)
+    assert result_keep.attrs == data.attrs
+
+    with xr.set_options(keep_attrs=False):
+        result_drop = xr.where(cond, data, other)
+    assert result_drop.attrs == {}
+
+
+def test_xr_where_keep_attrs_dataset() -> None:
+    cond = xr.DataArray([True, False], dims=["x"])
+    data = xr.Dataset(
+        {
+            "a": xr.DataArray([1, 2], dims=["x"], attrs={"va": "A"}),
+            "b": xr.DataArray([3, 4], dims=["x"], attrs={"vb": "B"}),
+        },
+        attrs={"ds": "data"},
+    )
+    other = xr.Dataset(
+        {
+            "a": xr.DataArray([5, 6], dims=["x"], attrs={"va": "YA"}),
+            "b": xr.DataArray([7, 8], dims=["x"], attrs={"vb": "YB"}),
+        },
+        attrs={"ds": "other"},
+    )
+
+    result_keep = xr.where(cond, data, other, keep_attrs=True)
+    assert result_keep.attrs == data.attrs
+    for name in data.data_vars:
+        assert result_keep[name].attrs == data[name].attrs
+
+    result_drop = xr.where(cond, data, other, keep_attrs=False)
+    assert result_drop.attrs == {}
+    for name in data.data_vars:
+        assert result_drop[name].attrs == {}


### PR DESCRIPTION
## Summary
- add `keep_attrs` support to `xr.where`, defaulting to the global option
- preserve Dataset variable attributes when attrs are retained
- add regression tests covering DataArray and Dataset attribute propagation

Closes #30.

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_where_attrs.py`
- `.venv/bin/flake8 xarray/core/computation.py xarray/tests/test_where_attrs.py`

## MCVE
```python
import numpy as np
import xarray as xr

cond = np.array([True, False])
data = xr.DataArray([1, 2], dims="x", attrs={"source": "x"})

with xr.set_options(keep_attrs=True):
    print(xr.where(cond, data, 0).attrs)
```
# output: {}

## Observed failure / stack trace / reproduction steps
none