### PR TITLE
Fix: xr.where keep_attrs with scalar arg (IndexError) [skip ci] (swev-id: pydata__xarray-6461)

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1829,7 +1829,14 @@ def where(cond, x, y, keep_attrs=None):
     if keep_attrs is True:
         # keep the attributes of x, the second parameter, by default to
         # be consistent with the `where` method of `DataArray` and `Dataset`
-        keep_attrs = lambda attrs, context: attrs[1]
+        def _combine_where_attrs(variable_attrs, context=None):
+            for source in (x, y, cond):
+                source_attrs = getattr(source, "attrs", None)
+                if source_attrs is not None:
+                    return dict(source_attrs)
+            return {}
+
+        keep_attrs = _combine_where_attrs
 
     # alignment for three arguments is complicated, so don't support it yet
     return apply_ufunc(

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1929,6 +1929,49 @@ def test_where_attrs() -> None:
     assert_identical(expected, actual)
 
 
+def test_where_keep_attrs_scalar_second_arg_prefers_y() -> None:
+    cond = xr.DataArray([True, False], dims="x")
+    y = xr.DataArray([0, 2], dims="x", attrs={"attr": "y"})
+
+    actual = xr.where(cond, 1, y, keep_attrs=True)
+    expected = xr.DataArray([1, 2], dims="x", attrs={"attr": "y"})
+    assert_identical(expected, actual)
+
+
+def test_where_keep_attrs_prefers_x_over_scalar_y() -> None:
+    cond = xr.DataArray([True, False], dims="x")
+    x = xr.DataArray([1, 1], dims="x", attrs={"attr": "x"})
+
+    actual = xr.where(cond, x, 0, keep_attrs=True)
+    expected = xr.DataArray([1, 0], dims="x", attrs={"attr": "x"})
+    assert_identical(expected, actual)
+
+
+def test_where_keep_attrs_all_scalars_use_cond_attrs() -> None:
+    cond = xr.DataArray([True, False], dims="x", attrs={"attr": "cond"})
+
+    actual = xr.where(cond, 1, 0, keep_attrs=True)
+    expected = xr.DataArray([1, 0], dims="x", attrs={"attr": "cond"})
+    assert_identical(expected, actual)
+
+
+def test_where_keep_attrs_all_scalars_numpy_inputs() -> None:
+    cond = np.array([True, False])
+
+    actual = xr.where(cond, 1, 0, keep_attrs=True)
+    assert_array_equal(actual, np.array([1, 0]))
+
+
+def test_where_keep_attrs_false_drops_attrs() -> None:
+    cond = xr.DataArray([True, False], dims="x", attrs={"attr": "cond"})
+    x = xr.DataArray([1, 1], dims="x", attrs={"attr": "x"})
+    y = xr.DataArray([0, 0], dims="x", attrs={"attr": "y"})
+
+    actual = xr.where(cond, x, y, keep_attrs=False)
+    expected = xr.DataArray([1, 0], dims="x")
+    assert_identical(expected, actual)
+
+
 @pytest.mark.parametrize("use_dask", [True, False])
 @pytest.mark.parametrize("use_datetime", [True, False])
 def test_polyval(use_dask, use_datetime) -> None:


### PR DESCRIPTION
## Summary
- replace the keep_attrs=True handling in `xr.where` with a safe selector that prefers x → y → cond when sourcing attrs
- add regression coverage for scalar inputs (x scalar, y scalar, numpy inputs) and keep_attrs=False for Attribute propagation
- keep behaviour consistent with DataArray.where while avoiding IndexError when only one xarray input provides attrs

## Issue Reference
Fixes #34

## Reproduction Details
The failure reproduced on Python 3.11.14 / NumPy 1.26.4 / pandas 2.3.3 / xarray 2022.3.1.dev43+g851dadeb0.

```python
import numpy as np
import xarray as xr
import sys, traceback

print("Environment:")
print(f"  Python {sys.version.split()[0]}")
print(f"  NumPy  {np.__version__}")
print(f"  xarray {xr.__version__}")

cond = xr.DataArray([True, False, True], dims=("x",))

da = xr.DataArray([1, 2, 3], dims=("x",), attrs={"source": "mcve"})

for label, args in [
    ("Case C: both scalars", (cond, 1, 0)),
    ("Case D: numpy arrays", (cond, np.zeros(3), np.ones(3))),
]:
    print(f"\n{label}")
    try:
        result = xr.where(*args, keep_attrs=True)
    except Exception:
        traceback.print_exc()
```

Stack trace (excerpt):

```
File "xarray/core/computation.py", line 1832, in <lambda>
    keep_attrs = lambda attrs, context: attrs[1]
IndexError: list index out of range
```

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_computation.py::test_where_keep_attrs_scalar_second_arg_prefers_y xarray/tests/test_computation.py::test_where_keep_attrs_prefers_x_over_scalar_y xarray/tests/test_computation.py::test_where_keep_attrs_all_scalars_use_cond_attrs xarray/tests/test_computation.py::test_where_keep_attrs_all_scalars_numpy_inputs xarray/tests/test_computation.py::test_where_keep_attrs_false_drops_attrs`