### PR TITLE
swev-id: pydata__xarray-4966 fix pydap unsigned byte decoding

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -308,14 +308,31 @@ class UnsignedIntegerCoder(VariableCoder):
         if "_Unsigned" in attrs:
             unsigned = pop_to(attrs, encoding, "_Unsigned")
 
+            if isinstance(unsigned, (bool, np.bool_)):
+                unsigned_value = "true" if bool(unsigned) else "false"
+            elif isinstance(unsigned, str):
+                unsigned_value = unsigned.strip().lower()
+            else:
+                unsigned_value = unsigned
+
             if data.dtype.kind == "i":
-                if unsigned == "true":
+                if unsigned_value == "true":
                     unsigned_dtype = np.dtype("u%s" % data.dtype.itemsize)
                     transform = partial(np.asarray, dtype=unsigned_dtype)
                     data = lazy_elemwise_func(data, transform, unsigned_dtype)
                     if "_FillValue" in attrs:
                         new_fill = unsigned_dtype.type(attrs["_FillValue"])
                         attrs["_FillValue"] = new_fill
+            elif data.dtype.kind == "u":
+                if data.dtype.itemsize == 1 and (
+                    unsigned_value == "false" or unsigned_value is False
+                ):
+                    signed_dtype = np.dtype("i1")
+                    transform = partial(np.asarray, dtype=signed_dtype)
+                    data = lazy_elemwise_func(data, transform, signed_dtype)
+                    for attr_name in ("_FillValue", "missing_value"):
+                        if attr_name in attrs:
+                            attrs[attr_name] = signed_dtype.type(attrs[attr_name])
             else:
                 warnings.warn(
                     "variable %r has _Unsigned attribute but is not "

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3564,6 +3564,24 @@ class TestPydap:
             )
         return ds
 
+    def _create_pydap_byte_dataset(self, unsigned_attr=None):
+        from pydap.model import BaseType, DatasetType
+
+        values = np.array([0, 127, 128, 255], dtype="uint8")
+        attrs = {}
+        if unsigned_attr is not None:
+            attrs["_Unsigned"] = unsigned_attr
+
+        dataset = DatasetType("unsigned_bytes")
+        dataset["dim"] = BaseType("dim", np.arange(values.size), dims=("dim",))
+        dataset["byte_var"] = BaseType(
+            "byte_var",
+            values,
+            dims=("dim",),
+            attributes=attrs,
+        )
+        return dataset, values
+
     @contextlib.contextmanager
     def create_datasets(self, **kwargs):
         with open_example_dataset("bears.nc") as expected:
@@ -3620,6 +3638,49 @@ class TestPydap:
     def test_dask(self):
         with self.create_datasets(chunks={"j": 2}) as (actual, expected):
             assert_equal(actual, expected)
+
+    @pytest.mark.parametrize("unsigned_attr", ["false", "FALSE", False])
+    def test_unsigned_false_byte_decoding(self, unsigned_attr):
+        pydap_ds, values = self._create_pydap_byte_dataset(unsigned_attr)
+        with open_dataset(PydapDataStore(pydap_ds)) as actual:
+            decoded = actual["byte_var"]
+            assert decoded.dtype == np.dtype("int8")
+            expected = np.asarray(values, dtype="int8")
+            assert_array_equal(decoded.values, expected)
+
+    @requires_netCDF4
+    def test_pydap_netcdf4_unsigned_false_parity(self):
+        pydap_ds, _ = self._create_pydap_byte_dataset("false")
+        with open_dataset(PydapDataStore(pydap_ds)) as pydap_decoded:
+            with create_tmp_file() as tmp_path:
+                import netCDF4
+
+                root = netCDF4.Dataset(tmp_path, mode="w")
+                try:
+                    root.createDimension("dim", 4)
+                    var = root.createVariable("byte_var", "u1", ("dim",))
+                    var[:] = np.array([0, 127, 128, 255], dtype="uint8")
+                    var.setncattr("_Unsigned", "false")
+                finally:
+                    root.close()
+
+                with open_dataset(tmp_path, engine="netcdf4") as netcdf_decoded:
+                    assert_array_equal(
+                        pydap_decoded["byte_var"].values,
+                        netcdf_decoded["byte_var"].values,
+                    )
+                    assert (
+                        pydap_decoded["byte_var"].dtype
+                        == netcdf_decoded["byte_var"].dtype
+                        == np.dtype("int8")
+                    )
+
+    def test_unsigned_attribute_absent_preserves_uint8(self):
+        pydap_ds, values = self._create_pydap_byte_dataset()
+        with open_dataset(PydapDataStore(pydap_ds)) as actual:
+            decoded = actual["byte_var"]
+            assert decoded.dtype == np.dtype("uint8")
+            assert_array_equal(decoded.values, values)
 
 
 @network


### PR DESCRIPTION
## Summary
- normalize `_Unsigned` metadata so boolean/string values compare consistently
- decode uint8 variables with `_Unsigned=false` as signed int8 and coerce fill metadata
- add regression tests covering Pydap decoding, engine parity with netCDF4, and the unsigned control case

## Testing
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/pytest -q xarray/tests/test_backends.py::TestPydap::test_unsigned_false_byte_decoding xarray/tests/test_backends.py::TestPydap::test_pydap_netcdf4_unsigned_false_parity xarray/tests/test_backends.py::TestPydap::test_unsigned_attribute_absent_preserves_uint8
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 xarray/coding/variables.py xarray/tests/test_backends.py

## MCVE (pre-fix failure)
```
LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/python - <<'PY'
import numpy as np
from pydap.model import BaseType, DatasetType
from xarray.backends.pydap_ import PydapDataStore
import xarray as xr

values = np.array([0, 127, 128, 255], dtype='uint8')
byte_var = BaseType('byte_var', values, dims=('dim',), attributes={'_Unsigned': 'false'})

store = DatasetType('test')
store['dim'] = BaseType('dim', np.arange(values.size), dims=('dim',))
store['byte_var'] = byte_var

xr_ds = xr.open_dataset(PydapDataStore(store))
var = xr_ds['byte_var']
assert var.dtype == np.int8, f"Expected int8 dtype, got {var.dtype}"
PY
/workspace/xarray/xarray/conventions.py:512: SerializationWarning: variable 'byte_var' has _Unsigned attribute but is not of integer type. Ignoring attribute.
Traceback (most recent call last):
  File "<stdin>", line 16, in <module>
AssertionError: Expected int8 dtype, got uint8
```

Fixes #32
Task 310