### PR TITLE
fix: swev-id: pydata__xarray-6599 handle timedelta coords

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1933,11 +1933,19 @@ def _ensure_numeric(data: T_Xarray) -> T_Xarray:
     from .dataset import Dataset
 
     def to_floatable(x: DataArray) -> DataArray:
-        if x.dtype.kind in "mM":
+        if x.dtype.kind == "M":
             return x.copy(
                 data=datetime_to_numeric(
                     x.data,
                     offset=np.datetime64("1970-01-01"),
+                    datetime_unit="ns",
+                ),
+            )
+        if x.dtype.kind == "m":
+            return x.copy(
+                data=datetime_to_numeric(
+                    x.data,
+                    offset=np.timedelta64(0, "ns"),
                     datetime_unit="ns",
                 ),
             )

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -2028,6 +2028,103 @@ def test_polyval(
     xr.testing.assert_allclose(actual, expected)
 
 
+def _polyval_expected_from_numeric(
+    numeric: xr.DataArray, coeffs: xr.DataArray
+) -> xr.DataArray:
+    numeric = numeric.astype(float)
+    max_degree = int(coeffs.coords["degree"].max().item())
+    result = xr.zeros_like(numeric, dtype=float) + float(
+        coeffs.sel(degree=max_degree)
+    )
+    for degree in range(max_degree - 1, -1, -1):
+        result = result * numeric + float(coeffs.sel(degree=degree))
+    return result
+
+
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_polyval_timedelta_dataarray(use_dask: bool) -> None:
+    coord = xr.DataArray(
+        np.array(
+            [
+                [np.timedelta64(-2, "h"), np.timedelta64(0, "ns")],
+                [np.timedelta64(36, "m"), np.timedelta64("NaT", "ns")],
+            ],
+            dtype="timedelta64[ns]",
+        ),
+        dims=("x", "y"),
+        coords={"x": ["row0", "row1"], "y": ["col0", "col1"]},
+    )
+    coeffs = xr.DataArray(
+        np.array([1.5, -0.25, 0.01], dtype=float),
+        dims="degree",
+        coords={"degree": [0, 1, 2]},
+    )
+
+    numeric = coord / np.timedelta64(1, "ns")
+    expected = _polyval_expected_from_numeric(numeric, coeffs)
+
+    coord_in = coord
+    coeffs_in = coeffs
+    if use_dask:
+        if not has_dask:
+            pytest.skip("requires dask")
+        coord_in = coord.chunk({"x": 1, "y": 2})
+        coeffs_in = coeffs.chunk({"degree": 1})
+
+    with raise_if_dask_computes():
+        actual = xr.polyval(coord=coord_in, coeffs=coeffs_in)
+
+    xr.testing.assert_allclose(actual, expected)
+    assert actual.dtype == np.float64
+
+
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_polyval_timedelta_dataset(use_dask: bool) -> None:
+    coord = xr.Dataset(
+        {
+            "east": ("lat", np.array([
+                np.timedelta64(-12, "h"),
+                np.timedelta64("NaT", "ns"),
+                np.timedelta64(18, "h"),
+            ], dtype="timedelta64[ns]")),
+            "west": (("lat", "lon"), np.array([
+                [np.timedelta64(0, "ns"), np.timedelta64(30, "m")],
+                [np.timedelta64(-45, "m"), np.timedelta64("NaT", "ns")],
+                [np.timedelta64(2, "h"), np.timedelta64(-90, "m")],
+            ], dtype="timedelta64[ns]")),
+        },
+        coords={"lat": ["south", "mid", "north"], "lon": ["west", "east"]},
+    )
+    coeffs = xr.Dataset(
+        {
+            "east": ("degree", np.array([1.0, 0.5, -0.125], dtype=float)),
+            "west": ("degree", np.array([2, -1, 1], dtype=np.int64)),
+        },
+        coords={"degree": [0, 1, 2]},
+    )
+
+    expected_vars = {}
+    for name, var in coord.data_vars.items():
+        numeric = var / np.timedelta64(1, "ns")
+        expected_vars[name] = _polyval_expected_from_numeric(numeric, coeffs[name])
+    expected = xr.Dataset(expected_vars, coords=coord.coords)
+
+    coord_in = coord
+    coeffs_in = coeffs
+    if use_dask:
+        if not has_dask:
+            pytest.skip("requires dask")
+        coord_in = coord.chunk({"lat": 2, "lon": 1})
+        coeffs_in = coeffs.chunk({"degree": 1})
+
+    with raise_if_dask_computes():
+        actual = xr.polyval(coord=coord_in, coeffs=coeffs_in)
+
+    xr.testing.assert_allclose(actual, expected)
+    for var in actual.data_vars.values():
+        assert var.dtype == np.float64
+
+
 def test_polyval_degree_dim_checks():
     x = (xr.DataArray([1, 2, 3], dims="x"),)
     coeffs = xr.DataArray([2, 3, 4], dims="degree", coords={"degree": [0, 1, 2]})


### PR DESCRIPTION
## Summary
- convert timedelta variables in `_ensure_numeric` using a zero timedelta offset so timedeltas are evaluated in nanoseconds
- preserve datetime handling while ensuring NaT values propagate as `np.nan`
- add regression coverage for DataArray and Dataset polyval with timedelta coordinates, including NaT and mixed coefficient dtypes

## Issue
- Resolves #35

## Reproduction
```
LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib \
PYTHONPATH=. .venv/bin/python - <<'PY'
import numpy as np
import xarray as xr

time = xr.DataArray(
    np.array([np.timedelta64(0, 'ns'), np.timedelta64(1, 'D')]),
    dims='tau',
)
coeffs = xr.DataArray(
    np.array([1.0, 2.0]),
    dims='degree',
    coords={'degree': [0, 1]},
)
xr.polyval(time, coeffs, degree_dim='degree')
PY
```

Observed stack trace prior to the fix:
```
Traceback (most recent call last):
  File "<stdin>", line 14, in <module>
  File "/workspace/xarray/xarray/core/computation.py", line 1908, in polyval
    coord = _ensure_numeric(coord)  # type: ignore # https://github.com/python/mypy/issues/1533 ?
  File "/workspace/xarray/xarray/core/computation.py", line 1949, in _ensure_numeric
    return to_floatable(data)
           ^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/computation.py", line 1938, in to_floatable
    data=datetime_to_numeric(
         ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xarray/xarray/core/duck_array_ops.py", line 434, in datetime_to_numeric
    array = array - offset
            ~~~~~~^~~~~~~~
numpy.core._exceptions._UFuncBinaryResolutionError: ufunc 'subtract' cannot use operands with types dtype('<m8[ns]') and dtype('<M8[D]')
```

## Testing
- baseline: `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_computation.py::test_polyval`
- fix: `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_computation.py::test_polyval_timedelta_dataarray xarray/tests/test_computation.py::test_polyval_timedelta_dataset xarray/tests/test_computation.py::test_polyval`
- lint: `.venv/bin/flake8 xarray/tests/test_computation.py xarray/core/computation.py`

Environment: Python 3.11.14 (nixpkgs), numpy 1.26.4, pandas 1.5.3, pytest 8.2.2, flake8 3.9.2, LD_LIBRARY_PATH configured per repo guidance.