### PR TITLE
swev-id: pydata__xarray-6744 fix DataArrayRolling center iteration

### DIFF
--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -270,13 +270,26 @@ class DataArrayRolling(Rolling["DataArray"]):
     def __iter__(self) -> Iterator[tuple[RollingKey, DataArray]]:
         if self.ndim > 1:
             raise ValueError("__iter__ is only supported for 1d-rolling")
-        stops = np.arange(1, len(self.window_labels) + 1)
-        starts = stops - int(self.window[0])
-        starts[: int(self.window[0])] = 0
-        for (label, start, stop) in zip(self.window_labels, starts, stops):
-            window = self.obj.isel({self.dim[0]: slice(start, stop)})
+        window_size = int(self.window[0])
+        dim = self.dim[0]
+        labels = self.window_labels
+        size = len(labels)
 
-            counts = window.count(dim=self.dim[0])
+        if self.center[0]:
+            left = window_size // 2
+            right = window_size - 1 - left
+            indices = np.arange(size)
+            starts = np.maximum(0, indices - left)
+            stops = np.minimum(size, indices + right + 1)
+        else:
+            stops = np.arange(1, size + 1)
+            starts = stops - window_size
+            starts[:window_size] = 0
+
+        for (label, start, stop) in zip(labels, starts, stops):
+            window = self.obj.isel({dim: slice(int(start), int(stop))})
+
+            counts = window.count(dim=dim)
             window = window.where(counts >= self.min_periods)
 
             yield (label, window)

--- a/xarray/tests/test_rolling.py
+++ b/xarray/tests/test_rolling.py
@@ -49,6 +49,37 @@ class TestDataArrayRolling:
                     expected.values[expected.values.nonzero()],
                 )
 
+    @pytest.mark.parametrize(
+        "window,min_periods",
+        ((3, None), (4, None), (4, 1)),
+    )
+    def test_rolling_iter_center_alignment(
+        self, window: int, min_periods: int | None
+    ) -> None:
+        da = xr.DataArray(
+            np.arange(8, dtype=float),
+            dims="time",
+            coords={"time": np.arange(8)},
+        )
+
+        rolling_kwargs: dict[str, Any] = {"time": window, "center": True}
+        if min_periods is not None:
+            rolling_kwargs["min_periods"] = min_periods
+
+        rolling_obj = da.rolling(**rolling_kwargs)
+        rolling_obj_mean = rolling_obj.mean()
+
+        assert len(rolling_obj.window_labels) == len(da["time"])
+        assert_identical(rolling_obj.window_labels, da["time"])
+
+        for i, (label, window_da) in enumerate(rolling_obj):
+            assert label == da["time"].isel(time=i)
+
+            expected = window_da.mean("time")
+            actual = rolling_obj_mean.isel(time=i)
+            assert_identical(actual.coords["time"], label)
+            assert_identical(actual.reset_coords(drop=True), expected)
+
     @pytest.mark.parametrize("da", (1,), indirect=True)
     def test_rolling_repr(self, da) -> None:
         rolling_obj = da.rolling(time=7)


### PR DESCRIPTION
## Summary
- honor centered windows in DataArrayRolling.__iter__
- add regression coverage for centered manual iteration alignment

## Reproduction
1. Construct a 1d DataArray and call `rolling(time=<w>, center=True)`.
2. Iterate the `DataArrayRolling` object, taking `window.mean()` per step.
3. Compare the manual results to `rolling(...).mean()`.

**Observed failure:** manual iteration yields left-anchored slices so the mean differs from the reduction (no stack trace, just numeric mismatch).

Tests were added alongside the fix.

Fixes #40