### PR TITLE
swev-id: pydata__xarray-6938 fix swap_dims mutation regression

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -3772,8 +3772,7 @@ class Dataset(
         for k, v in self.variables.items():
             dims = tuple(dims_dict.get(dim, dim) for dim in v.dims)
             if k in result_dims:
-                var = v.to_index_variable()
-                var.dims = dims
+                var = v.to_index_variable()._replace(dims=dims)
                 if k in self._indexes:
                     indexes[k] = self._indexes[k]
                     variables[k] = var
@@ -3783,8 +3782,7 @@ class Dataset(
                     variables.update(index_vars)
                     coord_names.update(index_vars)
             else:
-                var = v.to_base_variable()
-                var.dims = dims
+                var = v.to_base_variable()._replace(dims=dims)
                 variables[k] = var
 
         return self._replace_with_new_dims(variables, coord_names, indexes=indexes)

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -1793,6 +1793,23 @@ class TestDataArray:
         for dim_name in set().union(expected.xindexes.keys(), actual.xindexes.keys()):
             assert actual.xindexes[dim_name].equals(expected.xindexes[dim_name])
 
+    def test_swap_dims_does_not_mutate_original(self) -> None:
+        array = DataArray(
+            [0, 1],
+            coords={"x": ("x", [0, 1]), "y": ("x", ["a", "b"])},
+            dims="x",
+        )
+
+        swapped = array.swap_dims({"x": "y"})
+
+        assert array.dims == ("x",)
+        assert array.coords["x"].dims == ("x",)
+        assert array.coords["y"].dims == ("x",)
+
+        assert swapped.dims == ("y",)
+        assert swapped.coords["x"].dims == ("y",)
+        assert swapped.coords["y"].dims == ("y",)
+
     def test_expand_dims_error(self) -> None:
         array = DataArray(
             np.random.randn(3, 4),

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -2995,6 +2995,47 @@ class TestDataset:
         assert isinstance(actual.variables["x"], Variable)
         assert actual.xindexes["y"].equals(expected.xindexes["y"])
 
+    def test_swap_dims_does_not_mutate_original(self) -> None:
+        ds = Dataset(
+            data_vars={"value": ("x", [0, 1])},
+            coords={"x": ("x", [0, 1]), "y": ("x", ["a", "b"])},
+        )
+
+        swapped = ds.swap_dims({"x": "y"})
+
+        assert ds.dims == {"x": 2}
+        assert ds.coords["x"].dims == ("x",)
+        assert ds.coords["y"].dims == ("x",)
+
+        assert swapped.dims == {"y": 2}
+        assert swapped.coords["y"].dims == ("y",)
+        assert swapped.coords["x"].dims == ("y",)
+
+    def test_swap_dims_chained_no_mutation(self) -> None:
+        ds = Dataset(
+            data_vars={"value": ("x", [0, 1])},
+            coords={
+                "x": ("x", [0, 1]),
+                "y": ("x", ["a", "b"]),
+                "z": ("x", ["alpha", "beta"]),
+            },
+        )
+
+        first = ds.swap_dims({"x": "y"})
+        second = first.swap_dims({"y": "z"})
+
+        assert ds.coords["x"].dims == ("x",)
+        assert ds.coords["y"].dims == ("x",)
+        assert ds.coords["z"].dims == ("x",)
+
+        assert first.dims == {"y": 2}
+        assert first.coords["x"].dims == ("y",)
+        assert first.coords["y"].dims == ("y",)
+        assert first.coords["z"].dims == ("y",)
+
+        expected = ds.swap_dims({"x": "z"}).set_coords("y")
+        assert_identical(expected, second)
+
     def test_expand_dims_error(self) -> None:
         original = Dataset(
             {


### PR DESCRIPTION
## Summary
- ensure `Dataset.swap_dims` and related code use `_replace` so new variables are constructed without mutating originals
- add dataset/dataarray regression tests covering non-mutation and chained calls to `.swap_dims`
- verify MCVE from #41 now holds invariants

Closes #41.

## Reproduction
1. Construct the dataset described in #41 using `stack`ed coordinates
2. Call `swap_dims({"1": "1_"})`
3. Run `xr.testing._assert_internal_invariants(state2, False)` and inspect `state.variables['1_'].dims`

### Observed failure (pre-fix)
```text
Checking state invariants ...
Checking state2 invariants ...
Traceback (most recent call last):
  File "<stdin>", line 27, in <module>
  File "/workspace/xarray-bug/xarray/testing.py", line 399, in _assert_internal_invariants
    _assert_dataset_invariants(
  File "/workspace/xarray-bug/xarray/testing.py", line 375, in _assert_dataset_invariants
    _assert_indexes_invariants_checks(
  File "/workspace/xarray-bug/xarray/testing.py", line 293, in _assert_indexes_invariants_checks
    assert name in indexes, (name, set(indexes))
AssertionError: ('2', {'0', '1_'})
```

## Testing
- export LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib && .venv/bin/pytest -q xarray/tests/test_dataset.py::TestDataset::test_swap_dims_does_not_mutate_original xarray/tests/test_dataset.py::TestDataset::test_swap_dims_chained_no_mutation xarray/tests/test_dataarray.py::TestDataArray::test_swap_dims_does_not_mutate_original (3 passed, 0 failed, 0 skipped)
- .venv/bin/flake8 xarray/core/dataset.py xarray/tests/test_dataset.py xarray/tests/test_dataarray.py (no lint issues)

Commit(s) include `[skip ci]` per instructions.