### PR TITLE
fix: preserve attrs in xr.where (swev-id: pydata__xarray-7229)

### DIFF
--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1871,6 +1871,14 @@ def where(cond, x, y, keep_attrs=None):
             keep_attrs="override",
         )
         result.attrs = getattr(x, "attrs", {})
+
+        from .dataset import Dataset  # local import to avoid circular dependency
+
+        if isinstance(result, Dataset) and isinstance(x, Dataset):
+            for name, data_var in x.data_vars.items():
+                if name in result.data_vars:
+                    result[name].attrs = data_var.attrs.copy()
+
         return result
 
     # alignment for three arguments is complicated, so don't support it yet

--- a/xarray/core/computation.py
+++ b/xarray/core/computation.py
@@ -1860,7 +1860,18 @@ def where(cond, x, y, keep_attrs=None):
     if keep_attrs is True:
         # keep the attributes of x, the second parameter, by default to
         # be consistent with the `where` method of `DataArray` and `Dataset`
-        keep_attrs = lambda attrs, context: getattr(x, "attrs", {})
+        result = apply_ufunc(
+            duck_array_ops.where,
+            cond,
+            x,
+            y,
+            join="exact",
+            dataset_join="exact",
+            dask="allowed",
+            keep_attrs="override",
+        )
+        result.attrs = getattr(x, "attrs", {})
+        return result
 
     # alignment for three arguments is complicated, so don't support it yet
     return apply_ufunc(

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1991,6 +1991,58 @@ def test_where_keep_attrs_preserves_coordinate_attrs_dataset() -> None:
     assert result.coords["lat"].attrs == expected_lat_attrs
 
 
+def test_where_keep_attrs_preserves_dataset_variable_attrs() -> None:
+    lat = xr.DataArray([0, 1], dims="lat")
+    lat.attrs = {"units": "degrees_north", "description": "latitude"}
+    expected_lat_attrs = dict(lat.attrs)
+
+    cond = xr.DataArray([True, False], dims="lat", coords={"lat": lat})
+
+    x = xr.Dataset(
+        {
+            "temp": xr.DataArray(
+                [1.0, 2.0],
+                dims="lat",
+                coords={"lat": lat},
+                attrs={"units": "kelvin", "note": "primary"},
+            ),
+            "precip": xr.DataArray(
+                [5.0, 6.0],
+                dims="lat",
+                coords={"lat": lat},
+                attrs={"units": "mm", "note": "secondary"},
+            ),
+        },
+        attrs={"title": "dataset x"},
+    )
+
+    y = xr.Dataset(
+        {
+            "temp": xr.DataArray(
+                [3.0, 4.0],
+                dims="lat",
+                coords={"lat": lat},
+                attrs={"units": "celsius", "note": "other"},
+            ),
+            "precip": xr.DataArray(
+                [7.0, 8.0],
+                dims="lat",
+                coords={"lat": lat},
+                attrs={"units": "in", "note": "other"},
+            ),
+        },
+        attrs={"title": "dataset y"},
+    )
+
+    result = xr.where(cond, x, y, keep_attrs=True)
+
+    for name in x.data_vars:
+        assert result[name].attrs == x[name].attrs
+
+    assert result.coords["lat"].attrs == expected_lat_attrs
+    assert result.attrs == x.attrs
+
+
 @pytest.mark.parametrize(
     "use_dask", [pytest.param(False, id="nodask"), pytest.param(True, id="dask")]
 )

--- a/xarray/tests/test_computation.py
+++ b/xarray/tests/test_computation.py
@@ -1937,6 +1937,60 @@ def test_where_attrs() -> None:
     assert actual.attrs == {}
 
 
+def test_where_keep_attrs_preserves_coordinate_attrs_dataarray() -> None:
+    lat = xr.DataArray([0, 1], dims="lat")
+    lat.attrs = {"units": "degrees_north", "description": "latitude"}
+    expected_lat_attrs = dict(lat.attrs)
+
+    cond = xr.DataArray([True, False], dims="lat", coords={"lat": lat})
+    x_attrs = {"units": "kelvin", "description": "x"}
+    y_attrs = {"units": "celsius", "description": "y"}
+    x = xr.DataArray([1, 2], dims="lat", coords={"lat": lat}, attrs=x_attrs.copy())
+    y = xr.DataArray([3, 4], dims="lat", coords={"lat": lat}, attrs=y_attrs)
+
+    result = xr.where(cond, x, y, keep_attrs=True)
+
+    assert result.attrs == x_attrs
+    assert result.coords["lat"].attrs == expected_lat_attrs
+
+
+def test_where_keep_attrs_preserves_coordinate_attrs_dataset() -> None:
+    lat = xr.DataArray([0, 1], dims="lat")
+    lat.attrs = {"units": "degrees_north", "description": "latitude"}
+    expected_lat_attrs = dict(lat.attrs)
+
+    cond = xr.DataArray([True, False], dims="lat", coords={"lat": lat})
+
+    x = xr.Dataset(
+        {
+            "temp": xr.DataArray(
+                [1.0, 2.0],
+                dims="lat",
+                coords={"lat": lat},
+                attrs={"units": "kelvin"},
+            )
+        },
+        attrs={"title": "dataset x"},
+    )
+
+    y = xr.Dataset(
+        {
+            "temp": xr.DataArray(
+                [3.0, 4.0],
+                dims="lat",
+                coords={"lat": lat},
+                attrs={"units": "celsius"},
+            )
+        },
+        attrs={"title": "dataset y"},
+    )
+
+    result = xr.where(cond, x, y, keep_attrs=True)
+
+    assert result.attrs == x.attrs
+    assert result.coords["lat"].attrs == expected_lat_attrs
+
+
 @pytest.mark.parametrize(
     "use_dask", [pytest.param(False, id="nodask"), pytest.param(True, id="dask")]
 )


### PR DESCRIPTION
## Summary
- ensure `xr.where(..., keep_attrs=True)` uses `keep_attrs="override"` during `apply_ufunc`
- restore data variable attrs on the final result without clobbering coordinate metadata
- add regression coverage for DataArray and Dataset use cases (#43)

## Reproduction (MCVE)
1. Activate the project virtualenv and ensure `pooch` + `scipy` are installed.
2. Run the script below:

```python
import xarray as xr

ds = xr.tutorial.load_dataset("air_temperature")
da = ds["air"]

lat_attrs = da.coords["lat"].attrs.copy()
dataset_lat_attrs = ds.coords["lat"].attrs.copy()

result_da = xr.where(da > 250, da, da, keep_attrs=True)
if result_da.coords["lat"].attrs != lat_attrs:
    raise AssertionError(
        f"lat attrs mutated\nexpected: {lat_attrs}\nactual: {result_da.coords['lat'].attrs}"
    )

result_ds = xr.where(ds > 250, ds, ds, keep_attrs=True)
if result_ds.coords["lat"].attrs != dataset_lat_attrs:
    raise AssertionError(
        f"dataset lat attrs mutated\nexpected: {dataset_lat_attrs}\nactual: {result_ds.coords['lat'].attrs}"
    )
```

### Observed failure prior to this patch
```
Traceback (most recent call last):
  File "<stdin>", line 8, in <module>
AssertionError: lat attrs mutated
expected: {'standard_name': 'latitude', 'long_name': 'Latitude', 'units': 'degrees_north', 'axis': 'Y'}
actual: {'long_name': '4xDaily Air temperature at sigma level 995', 'units': 'degK', 'precision': 2, 'GRIB_id': 11, 'GRIB_name': 'TMP', 'var_desc': 'Air temperature', 'dataset': 'NMC Reanalysis', 'level_desc': 'Surface', 'statistic': 'Individual Obs', 'parent_stat': 'Other', 'actual_range': array([185.16, 322.1 ], dtype='>f4')}
```
```
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
AssertionError: dataset lat attrs mutated
expected: {'standard_name': 'latitude', 'long_name': 'Latitude', 'units': 'degrees_north', 'axis': 'Y'}
actual: {'Conventions': 'COARDS', 'title': '4x daily NMC reanalysis (1948)', 'description': 'Data is from NMC initialized reanalysis
(4x/day).  These are the 0.9950 sigma level values.', 'platform': 'Model', 'references': 'http://www.esrl.noaa.gov/psd/data/gridded/data.ncep.reanalysis.html'}
```

## Fix Details
- avoid passing a callable to `apply_ufunc` when `keep_attrs=True`; instead rely on `keep_attrs="override"`
- explicitly transfer `x.attrs` to the result after `apply_ufunc` so only the data variable metadata is propagated
- add regression tests confirming coordinate attrs remain intact for both DataArray and Dataset results while the output attrs match `x`

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_computation.py -k where --maxfail=1`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_computation.py::test_where_keep_attrs_preserves_coordinate_attrs_dataarray xarray/tests/test_computation.py::test_where_keep_attrs_preserves_coordinate_attrs_dataset`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 xarray/core/computation.py xarray/tests/test_computation.py`

Resolves #43