### PR TITLE
swev-id: pydata__xarray-6992 - fix DataVariables len invariant

### DIFF
--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -365,7 +365,9 @@ class DataVariables(Mapping[Any, "DataArray"]):
         )
 
     def __len__(self) -> int:
-        return len(self._dataset._variables) - len(self._dataset._coord_names)
+        variables = self._dataset._variables
+        coord_names = self._dataset._coord_names
+        return len(variables) - len(coord_names & variables.keys())
 
     def __contains__(self, key: Hashable) -> bool:
         return key in self._dataset._variables and key not in self._dataset._coord_names
@@ -955,6 +957,8 @@ class Dataset(
             dims = calculate_dimensions(variables)
         if indexes is None:
             indexes = {}
+        coord_names = coord_names & variables.keys()
+
         obj = object.__new__(cls)
         obj._variables = variables
         obj._coord_names = coord_names
@@ -987,7 +991,9 @@ class Dataset(
             if variables is not None:
                 self._variables = variables
             if coord_names is not None:
-                self._coord_names = coord_names
+                self._coord_names = coord_names & self._variables.keys()
+            elif variables is not None:
+                self._coord_names = self._coord_names & self._variables.keys()
             if dims is not None:
                 self._dims = dims
             if attrs is not _default:
@@ -1002,6 +1008,7 @@ class Dataset(
                 variables = self._variables.copy()
             if coord_names is None:
                 coord_names = self._coord_names.copy()
+            coord_names = coord_names & variables.keys()
             if dims is None:
                 dims = self._dims.copy()
             if attrs is _default:
@@ -4099,7 +4106,9 @@ class Dataset(
                 new_dims = [replace_dims.get(d, d) for d in v.dims]
                 variables[k] = v._replace(dims=new_dims)
 
-        coord_names = self._coord_names - set(drop_variables) | set(new_variables)
+        coord_names = (
+            self._coord_names - set(drop_variables) | set(new_variables)
+        ) & variables.keys()
 
         return self._replace_with_new_dims(
             variables, coord_names=coord_names, indexes=indexes_
@@ -4177,7 +4186,7 @@ class Dataset(
         }
         variables.update(new_variables)
 
-        coord_names = set(new_variables) | self._coord_names
+        coord_names = (set(new_variables) | self._coord_names) & variables.keys()
 
         return self._replace(variables, coord_names=coord_names, indexes=indexes)
 
@@ -4541,7 +4550,9 @@ class Dataset(
                 else:
                     variables[name] = var
 
-        coord_names = set(self._coord_names) - {dim} | set(new_indexes)
+        coord_names = (
+            set(self._coord_names) - {dim} | set(new_indexes)
+        ) & variables.keys()
 
         return self._replace_with_new_dims(
             variables, coord_names=coord_names, indexes=indexes
@@ -4592,7 +4603,9 @@ class Dataset(
                 else:
                     variables[name] = var
 
-        coord_names = set(self._coord_names) - {dim} | set(new_dim_sizes)
+        coord_names = (
+            set(self._coord_names) - {dim} | set(new_dim_sizes)
+        ) & variables.keys()
 
         return self._replace_with_new_dims(
             variables, coord_names=coord_names, indexes=indexes

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -220,6 +220,18 @@ class InaccessibleVariableDataStore(backends.InMemoryDataStore):
 
 
 class TestDataset:
+    @staticmethod
+    def _multiindex_example() -> Dataset:
+        return Dataset(
+            data_vars={"v": (("x", "y"), np.ones((2, 3)))},
+            coords={
+                "x": ("x", [0, 1]),
+                "y": ("y", [0, 1, 2]),
+                "a": ("x", [10, 20]),
+                "b": ("x", [100, 200]),
+            },
+        )
+
     def test_repr(self) -> None:
         data = create_test_data(seed=123)
         data.attrs["foo"] = "bar"
@@ -2125,6 +2137,59 @@ class TestDataset:
 
         assert_identical(expected, actual)
         assert actual.x.dtype == expected.x.dtype
+
+    def test_data_vars_len_never_negative_after_reset_index_drop(self) -> None:
+        base = self._multiindex_example()
+        result = base.set_index(x=["a", "b"]).reset_index("x", drop=True)
+
+        assert len(result.data_vars) == 1
+        assert list(result.data_vars) == ["v"]
+        assert "*empty*" not in repr(result)
+
+    def test_data_vars_len_after_reset_index_level_drop(self) -> None:
+        base = self._multiindex_example()
+        result = base.set_index(x=["a", "b"]).reset_index("a", drop=True)
+
+        assert len(result.data_vars) == 1
+        assert list(result.data_vars) == ["v"]
+        assert "*empty*" not in repr(result)
+
+    def test_data_vars_len_after_set_index_append_and_reset(self) -> None:
+        base = self._multiindex_example()
+        result = base.set_index(x=["a", "b"], append=True).reset_index("a", drop=True)
+
+        assert len(result.data_vars) == 1
+        assert list(result.data_vars) == ["v"]
+        assert "*empty*" not in repr(result)
+
+    def test_invariant_coord_names_subset_of_variables(self) -> None:
+        base = self._multiindex_example()
+        variants = [
+            base.set_index(x=["a", "b"]).reset_index("x", drop=True),
+            base.set_index(x=["a", "b"]).reset_index("a", drop=True),
+            base.set_index(x=["a", "b"], append=True).reset_index("a", drop=True),
+            base.set_index(x=["a", "b"]).reset_index("x", drop=True).reindex(
+                x=[0, 1], y=[0, 1, 2]
+            ),
+        ]
+
+        for ds in variants:
+            assert set(ds._coord_names) <= set(ds._variables)
+
+    def test_iter_data_vars_matches_len_and_keys(self) -> None:
+        base = self._multiindex_example()
+        reindexed = (
+            base.set_index(x=["a", "b"]).reset_index("x", drop=True).reindex(
+                x=[0, 1], y=[0, 1, 2]
+            )
+        )
+
+        iter_keys = list(reindexed.data_vars)
+        mapping_keys = list(reindexed.data_vars.keys())
+
+        assert len(reindexed.data_vars) == 1
+        assert iter_keys == ["v"]
+        assert iter_keys == mapping_keys
 
     @pytest.mark.parametrize("fill_value", [dtypes.NA, 2, 2.0, {"foo": 2, "bar": 1}])
     def test_align_fill_value(self, fill_value) -> None:


### PR DESCRIPTION
## Summary
- ensure DataVariables.__len__ counts only coordinates still tracked as variables
- intersect coord name sets with variable keys across dataset constructors (set_index, reset_index, unstack, reindex)
- add regression tests covering len/iter/repr invariants from Emerson's MCVE

## Testing
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib PYTHONPATH=/workspace/xarray .venv/bin/pytest -q xarray/tests/test_dataset.py -k "data_vars_len or invariant_coord_names_subset_of_variables or iter_data_vars_matches_len_and_keys"
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 xarray/core/dataset.py xarray/tests/test_dataset.py

Fixes #44