### PR TITLE
swev-id: pydata__xarray-6721

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -2023,14 +2023,13 @@ def get_chunksizes(
 
     chunks: dict[Any, tuple[int, ...]] = {}
     for v in variables:
-        if hasattr(v.data, "chunks"):
-            for dim, c in v.chunksizes.items():
-                if dim in chunks and c != chunks[dim]:
-                    raise ValueError(
-                        f"Object has inconsistent chunks along dimension {dim}. "
-                        "This can be fixed by calling unify_chunks()."
-                    )
-                chunks[dim] = c
+        for dim, c in v.chunksizes.items():
+            if dim in chunks and c != chunks[dim]:
+                raise ValueError(
+                    f"Object has inconsistent chunks along dimension {dim}. "
+                    "This can be fixed by calling unify_chunks()."
+                )
+            chunks[dim] = c
     return Frozen(chunks)
 
 

--- a/xarray/core/variable.py
+++ b/xarray/core/variable.py
@@ -1001,9 +1001,8 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
     @property
     def chunksizes(self) -> Mapping[Any, tuple[int, ...]]:
         """
-        Mapping from dimension names to block lengths for this variable's data, or None if
-        the underlying data is not a dask array.
-        Cannot be modified directly, but can be modified by calling .chunk().
+        Mapping from dimension names to block lengths for this variable's data.
+        Returns an empty mapping if chunking information is unavailable.
 
         Differs from variable.chunks because it returns a mapping of dimensions to chunk shapes
         instead of a tuple of chunk shapes.
@@ -1014,10 +1013,68 @@ class Variable(AbstractArray, NdimSizeLenMixin, VariableArithmetic):
         Variable.chunks
         xarray.unify_chunks
         """
-        if hasattr(self._data, "chunks"):
-            return Frozen({dim: c for dim, c in zip(self.dims, self.data.chunks)})
-        else:
-            return {}
+        def _normalize_chunks(item: Any, size: int) -> tuple[int, ...]:
+            if isinstance(item, tuple):
+                return tuple(int(x) for x in item)
+            if isinstance(item, list):
+                return tuple(int(x) for x in item)
+            if isinstance(item, numbers.Number):
+                chunk = int(item)
+                if chunk <= 0:
+                    return ()
+                full_chunks, remainder = divmod(size, chunk)
+                chunks = (chunk,) * full_chunks
+                if remainder:
+                    chunks += (remainder,)
+                if not chunks:
+                    chunks = (size,)
+                return chunks
+            return ()
+
+        def _from_mapping(mapping: Mapping[Any, Any]) -> dict[Any, tuple[int, ...]]:
+            result: dict[Any, tuple[int, ...]] = {}
+            for dim, size in zip(self.dims, self.shape):
+                if dim in mapping and mapping[dim] is not None:
+                    normalized = _normalize_chunks(mapping[dim], size)
+                    if normalized:
+                        result[dim] = normalized
+            return result
+
+        data_chunks = getattr(self._data, "chunks", None)
+        if data_chunks is not None:
+            if data_chunks and isinstance(data_chunks[0], (list, tuple)):
+                return Frozen(
+                    {
+                        dim: tuple(int(x) for x in chunk_tuple)
+                        for dim, chunk_tuple in zip(self.dims, data_chunks)
+                    }
+                )
+
+            normalized_chunks: dict[Any, tuple[int, ...]] = {}
+            for dim, size, chunk_item in zip(self.dims, self.shape, data_chunks):
+                normalized = _normalize_chunks(chunk_item, size)
+                if normalized:
+                    normalized_chunks[dim] = normalized
+            if normalized_chunks:
+                return Frozen(normalized_chunks)
+
+        encoding_chunks: dict[Any, tuple[int, ...]] = {}
+        preferred = self.encoding.get("preferred_chunks")
+        if utils.is_dict_like(preferred):
+            encoding_chunks.update(_from_mapping(preferred))
+
+        for key in ("chunks", "chunksizes"):
+            raw = self.encoding.get(key)
+            if not raw:
+                continue
+            if utils.is_dict_like(raw):
+                mapping = raw
+            else:
+                mapping = {dim: value for dim, value in zip(self.dims, raw)}
+            for dim, chunk_tuple in _from_mapping(mapping).items():
+                encoding_chunks.setdefault(dim, chunk_tuple)
+
+        return Frozen(encoding_chunks)
 
     _array_counter = itertools.count()
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1679,6 +1679,71 @@ class TestNetCDF4ViaDaskData(TestNetCDF4Data):
 
 
 @requires_zarr
+@requires_fsspec
+def test_open_zarr_chunks_metadata_only(monkeypatch) -> None:
+    from collections.abc import MutableMapping
+
+    from fsspec.implementations.memory import MemoryFileSystem
+
+    from xarray.core.variable import Variable
+
+    class RecordingStore(MutableMapping[str, bytes]):
+        METADATA_SUFFIXES = (".zarray", ".zattrs", ".zgroup", ".zmetadata")
+
+        def __init__(self, store: MutableMapping[str, bytes]) -> None:
+            self._store = store
+            self.data_reads: list[str] = []
+
+        def _is_data_chunk(self, key: str) -> bool:
+            suffix = key.rsplit("/", 1)[-1]
+            if suffix.startswith("."):
+                return False
+            return not key.endswith(self.METADATA_SUFFIXES)
+
+        def __getitem__(self, key: str) -> bytes:
+            value = self._store[key]
+            if self._is_data_chunk(key):
+                self.data_reads.append(key)
+            return value
+
+        def __setitem__(self, key: str, value: bytes) -> None:
+            self._store[key] = value
+
+        def __delitem__(self, key: str) -> None:
+            del self._store[key]
+
+        def __iter__(self):
+            return iter(self._store)
+
+        def __len__(self) -> int:
+            return len(self._store)
+
+    fs = MemoryFileSystem()
+    mapper = fs.get_mapper("materialization.zarr")
+
+    source = xr.Dataset({"foo": ("x", np.arange(10, dtype=np.int64))}).chunk({"x": 4})
+    source.to_zarr(mapper, mode="w")
+
+    store = RecordingStore(mapper)
+    ds = xr.open_zarr(store, chunks=None)
+
+    with monkeypatch.context() as m:
+        def _forbidden(self) -> None:
+            raise AssertionError("Variable.values accessed while reading chunks")
+
+        m.setattr(Variable, "values", property(_forbidden), raising=True)
+        chunks = ds.chunks
+        chunksizes = ds.chunksizes
+        var_chunksizes = ds["foo"].variable.chunksizes
+
+    expected = {"x": (4, 4, 2)}
+    assert dict(chunks) == expected
+    assert dict(chunksizes) == expected
+    assert dict(var_chunksizes) == expected
+    assert store.data_reads == []
+
+
+@requires_zarr
 class ZarrBase(CFEncodedBase):
 
     DIMENSION_KEY = "_ARRAY_DIMENSIONS"

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -1050,6 +1050,31 @@ class TestDataset:
             data.chunk({"foo": 10})
 
     @requires_dask
+    def test_chunk_properties_lazy_data(self) -> None:
+        import dask.array as da
+
+        lazy = da.ones((4, 6), chunks=(2, 3))
+        data = Dataset({"foo": (("x", "y"), lazy)})
+        array = data["foo"]
+
+        expected_tuple = lazy.chunks
+        expected_mapping = {dim: chunk for dim, chunk in zip(array.dims, expected_tuple)}
+
+        assert array.chunks == expected_tuple
+        assert dict(array.chunksizes) == expected_mapping
+        assert dict(data.chunks) == expected_mapping
+        assert dict(data.chunksizes) == expected_mapping
+
+    def test_chunksizes_numpy_data(self) -> None:
+        array = xr.DataArray(np.ones((2, 3)), dims=("x", "y"))
+        data = array.to_dataset(name="foo")
+
+        assert array.chunks is None
+        assert dict(array.chunksizes) == {}
+        assert dict(data.chunks) == {}
+        assert dict(data.chunksizes) == {}
+
+    @requires_dask
     def test_dask_is_lazy(self) -> None:
         store = InaccessibleVariableDataStore()
         create_test_data().dump_to_store(store)


### PR DESCRIPTION
## Summary
- avoid materializing backend arrays when computing Variable.chunksizes by normalizing dask chunk metadata or backend encodings
- update get_chunksizes to rely on normalized chunk mappings and add regression coverage for zarr stores and lazy/numpy datasets
- reproduced the materialization bug by wrapping a MemoryFileSystem mapper and asserting no chunk payload reads when calling Dataset.chunks

Fixes #37.

## Testing
- flake8 xarray/core/variable.py xarray/core/common.py xarray/tests/test_backends.py xarray/tests/test_dataset.py
- pytest -q xarray/tests/test_backends.py::test_open_zarr_chunks_metadata_only xarray/tests/test_dataset.py::TestDataset::test_chunk_properties_lazy_data xarray/tests/test_dataset.py::TestDataset::test_chunksizes_numpy_data