### PR TITLE
swev-id: pydata__xarray-7233 - preserve coords in coarsen construct

### DIFF
--- a/xarray/core/rolling.py
+++ b/xarray/core/rolling.py
@@ -973,8 +973,7 @@ class Coarsen(CoarsenArithmetic, Generic[T_Xarray]):
             else:
                 reshaped[key] = var
 
-        should_be_coords = set(window_dim) & set(self.obj.coords)
-        result = reshaped.set_coords(should_be_coords)
+        result = reshaped.set_coords(set(self.obj.coords))
         if isinstance(self.obj, DataArray):
             return self.obj._from_temp_dataset(result)
         else:

--- a/xarray/tests/test_coarsen.py
+++ b/xarray/tests/test_coarsen.py
@@ -318,3 +318,77 @@ def test_coarsen_construct(dask: bool) -> None:
 
     with pytest.raises(ValueError):
         ds.coarsen(time=12).construct(time=("bar",))
+
+
+def _build_monthly_dataset(length: int = 24) -> Dataset:
+    time = pd.date_range("2000-01-01", periods=length, freq="MS")
+    labels = np.array([f"L{i}" for i in range(length)])
+    return xr.Dataset(
+        data_vars={"a": ("time", np.arange(length))},
+        coords={
+            "time": time,
+            "label": ("time", labels, {"meta": "value"}),
+        },
+    )
+
+
+def test_coarsen_construct_preserves_nondim_coords() -> None:
+    ds = _build_monthly_dataset()
+
+    result = ds.coarsen(time=12).construct(time=("year", "month"))
+
+    assert "label" in result.coords
+    assert "label" not in result.data_vars
+    assert result["label"].dims == ("year", "month")
+    np.testing.assert_array_equal(
+        result["label"].data, ds["label"].data.reshape(2, 12)
+    )
+    assert result["label"].attrs == {"meta": "value"}
+
+
+def test_coarsen_construct_preserves_unrelated_coords() -> None:
+    ds = xr.Dataset(
+        data_vars={
+            "a": (("station", "time"), np.arange(48).reshape(2, 24)),
+        },
+        coords={
+            "time": pd.date_range("2000-01-01", periods=24, freq="MS"),
+            "station": ("station", ["s0", "s1"]),
+            "station_name": ("station", ["North", "South"]),
+        },
+    )
+
+    result = ds.coarsen(time=12).construct(time=("year", "month"))
+
+    assert "station_name" in result.coords
+    assert "station_name" not in result.data_vars
+    assert result.coords["station_name"].dims == ("station",)
+    np.testing.assert_array_equal(
+        result.coords["station_name"].data, ds.coords["station_name"].data
+    )
+
+
+def test_dataarray_coarsen_construct_preserves_nondim_coords() -> None:
+    ds = _build_monthly_dataset()
+    da = ds["a"].assign_coords(label=ds["label"])
+
+    result = da.coarsen(time=12).construct(time=("year", "month"))
+
+    assert "label" in result.coords
+    assert result.coords["label"].dims == ("year", "month")
+    np.testing.assert_array_equal(
+        result.coords["label"].data, ds["label"].data.reshape(2, 12)
+    )
+    assert result.coords["label"].attrs == {"meta": "value"}
+
+
+def test_coarsen_construct_preserves_nondim_coord_attrs() -> None:
+    ds = _build_monthly_dataset(length=12)
+
+    constructed = ds.coarsen(time=6).construct(time=("half", "month"))
+    assert constructed["label"].attrs == {"meta": "value"}
+
+    constructed_no_attrs = ds.coarsen(time=6).construct(
+        time=("half", "month"), keep_attrs=False
+    )
+    assert constructed_no_attrs["label"].attrs == {}


### PR DESCRIPTION
## Summary
- preserve all original coordinates when reshaping via `Coarsen.construct`
- add dataset and dataarray regression tests for non-dimensional and unrelated coordinates
- cover keep_attrs behaviour for non-dimensional coordinates

## MCVE
```python
from __future__ import annotations
import numpy as np
import pandas as pd
import xarray as xr

time = pd.date_range("2000-01-01", periods=24, freq="MS")
ds = xr.Dataset(
    data_vars={"a": ("time", np.arange(24))},
    coords={
        "time": time,
        "label": ("time", [f"L{i}" for i in range(24)]),
    },
)

print(list(ds.coords))
print(list(ds.data_vars))

out = ds.coarsen(time=12).construct(time=("year", "month"))
print(list(out.coords))
print(list(out.data_vars))
```

## Observed failure (before fix)
```
$ LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib \
    .venv/bin/pytest -q \
    xarray/tests/test_coarsen.py::test_coarsen_construct_preserves_nondim_coords \
    xarray/tests/test_coarsen.py::test_coarsen_construct_preserves_unrelated_coords \
    xarray/tests/test_coarsen.py::test_dataarray_coarsen_construct_preserves_nondim_coords \
    xarray/tests/test_coarsen.py::test_coarsen_construct_preserves_nondim_coord_attrs
________________ test_coarsen_construct_preserves_nondim_coords ________________
>       assert "label" in result.coords
E       AssertionError: assert 'label' in Coordinates:\n    time     (year, month) datetime64[ns] 2000-01-01 2000-02-01 ... 2001-12-01
E        +  where Coordinates:\n    time     (year, month) datetime64[ns] 2000-01-01 2000-02-01 ... 2001-12-01 = <xarray.Dataset>...

______________ test_coarsen_construct_preserves_unrelated_coords _______________
>       assert "station_name" in result.coords
E       AssertionError: assert 'station_name' in Coordinates:\n    time     (year, month) datetime64[ns] 2000-01-01 2000-02-01 ... 2001-12-01
```

## Reproduction steps
1. Checkout `pydata__xarray-7233`
2. Create the Python 3.11 virtualenv and install numpy 1.26.4, pandas 1.5.3, pytest 8.2.2, flake8 3.9.2, and jinja2
3. Run the pytest command above with the provided `LD_LIBRARY_PATH`

## Fix
- promote the complete coordinate set after reshaping by calling `reshaped.set_coords(set(self.obj.coords))`

## Regression tests
- `test_coarsen_construct_preserves_nondim_coords`
- `test_coarsen_construct_preserves_unrelated_coords`
- `test_dataarray_coarsen_construct_preserves_nondim_coords`
- `test_coarsen_construct_preserves_nondim_coord_attrs`

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_coarsen.py::test_coarsen_construct_preserves_nondim_coords xarray/tests/test_coarsen.py::test_coarsen_construct_preserves_unrelated_coords xarray/tests/test_coarsen.py::test_dataarray_coarsen_construct_preserves_nondim_coords xarray/tests/test_coarsen_construct_preserves_nondim_coord_attrs`
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_coarsen.py`
- `.venv/bin/flake8 xarray/tests/test_coarsen.py xarray/core/rolling.py`

Fixes #47
