### PR TITLE
swev-id: pydata__xarray-7393 — Preserve dtype for stacked level coords; fix __array__ cast

### DIFF
--- a/xarray/core/indexing.py
+++ b/xarray/core/indexing.py
@@ -1532,7 +1532,10 @@ class PandasMultiIndexingAdapter(PandasIndexingAdapter):
 
     def __array__(self, dtype: DTypeLike = None) -> np.ndarray:
         if self.level is not None:
-            return self.array.get_level_values(self.level).values
+            if dtype is None:
+                dtype = self.dtype
+            values = self.array.get_level_values(self.level).values
+            return np.asarray(values, dtype=dtype)
         else:
             return super().__array__(dtype)
 

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -3526,6 +3526,72 @@ class TestDataset:
         assert_identical(expected, actual)
         assert list(actual.xindexes) == ["z", "xx", "y"]
 
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array([-3, 0, 7], dtype=np.int32),
+            np.array([1, 2, 3], dtype=np.int64),
+            np.array([0.5, 1.25, -2.5], dtype=np.float32),
+            np.array([0.0, -1.5, 3.25], dtype=np.float64),
+            np.array(["a", "b", "c"], dtype="<U1"),
+        ],
+    )
+    def test_stack_preserves_level_dtype_single_level(self, values) -> None:
+        ds = xr.Dataset(coords={"x": ("x", values)})
+
+        stacked = ds.stack(z=("x",))
+        coord = stacked["x"]
+
+        expected_dtype = values.dtype
+        assert coord.dtype == expected_dtype
+        assert coord.values.dtype == expected_dtype
+
+    def test_stack_preserves_multiindex_level_dtypes(self) -> None:
+        ds = xr.Dataset(
+            data_vars={"v": (("x", "y"), np.arange(4).reshape(2, 2))},
+            coords={
+                "x": ("x", np.array([1, 2], dtype=np.int32)),
+                "y": ("y", np.array([0.5, 1.5], dtype=np.float32)),
+                "label": ("y", np.array(["a", "b"], dtype="<U1")),
+            },
+        )
+
+        stacked = ds.stack(z=("x", "y"))
+
+        x_coord = stacked["x"]
+        assert x_coord.dtype == np.dtype("int32")
+        assert x_coord.values.dtype == np.dtype("int32")
+
+        y_coord = stacked["y"]
+        assert y_coord.dtype == np.dtype("float32")
+        assert y_coord.values.dtype == np.dtype("float32")
+
+        label_coord = stacked["label"]
+        assert label_coord.dtype == np.dtype("<U1")
+        assert label_coord.values.dtype == np.dtype("<U1")
+
+        mindex_coord = stacked["z"]
+        assert mindex_coord.dtype == np.dtype("O")
+        assert mindex_coord.values.dtype == np.dtype("O")
+
+    def test_stack_unstack_roundtrip_preserves_dtypes(self) -> None:
+        ds = xr.Dataset(
+            data_vars={"value": (("x", "y"), np.arange(4).reshape(2, 2))},
+            coords={
+                "x": ("x", np.array([-2, 5], dtype=np.int32)),
+                "y": ("y", np.array([0.5, 1.5], dtype=np.float32)),
+                "label": ("y", np.array(["a", "b"], dtype="<U1")),
+            },
+        )
+
+        stacked = ds.stack(z=("x", "y"))
+        unstacked = stacked.unstack("z")
+
+        for name in ["x", "y", "label"]:
+            expected_dtype = ds[name].dtype
+            assert unstacked[name].dtype == expected_dtype
+            assert unstacked[name].values.dtype == ds[name].values.dtype
+
     def test_unstack(self) -> None:
         index = pd.MultiIndex.from_product([[0, 1], ["a", "b"]], names=["x", "y"])
         ds = Dataset(data_vars={"b": ("z", [0, 1, 2, 3])}, coords={"z": index})


### PR DESCRIPTION
## Summary
- Fixes #49; MCVE-1/MCVE-2 stacks now preserve the original level dtypes for int32, float32, and string levels.
- Root cause was PandasMultiIndexingAdapter.__array__ ignoring the preserved level dtype when materialising numpy arrays.
- Apply the targeted cast for level coordinates and add regression coverage for single-level, multi-index, and stack→unstack round-trips.

## Testing
- Python 3.11.14, numpy 1.26.4, pandas 1.5.3
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_dataset.py::TestDataset::test_stack_preserves_level_dtype_single_level xarray/tests/test_dataset.py::TestDataset::test_stack_preserves_multiindex_level_dtypes xarray/tests/test_dataset.py::TestDataset::test_stack_unstack_roundtrip_preserves_dtypes
  - 7 passed, 1 warning
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/gh2dd8vimringn726ndall19gbm77prj-openblas-0.3.30/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest -q xarray/tests/test_dataset.py::TestDataset::test_stack xarray/tests/test_dataset.py::TestDataset::test_stack_multi_index xarray/tests/test_dataset.py::TestDataset::test_unstack
  - 3 passed, 15 warnings
- .venv/bin/flake8 xarray/core/indexing.py xarray/tests/test_dataset.py
  - no issues